### PR TITLE
Add PathSegment and rename Path/PathSeq to PathParam/PathParams

### DIFF
--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,14 +1,14 @@
 extern crate finchers;
 
 use finchers::Endpoint;
-use finchers::endpoint::{query, segment, PathExt};
+use finchers::endpoint::{param, query, segment};
 use finchers::endpoint::method::get;
 use finchers::json::Json;
 use finchers::server::Server;
 
 fn main() {
     let endpoint = |_: &_| {
-        get(segment("hello").with(String::PATH))
+        get(segment("hello").with(param::<String>()))
             .join(query::<String>("foo"))
             .map(|(name, foo)| Json(format!("Hello, {}, {}", name, foo)))
     };

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,14 +1,14 @@
 extern crate finchers;
 
 use finchers::Endpoint;
-use finchers::endpoint::{query, PathExt};
+use finchers::endpoint::{query, segment, PathExt};
 use finchers::endpoint::method::get;
 use finchers::json::Json;
 use finchers::server::Server;
 
 fn main() {
     let endpoint = |_: &_| {
-        get("hello".with(String::PATH))
+        get(segment("hello").with(String::PATH))
             .join(query::<String>("foo"))
             .map(|(name, foo)| Json(format!("Hello, {}, {}", name, foo)))
     };

--- a/examples/run_tests.rs
+++ b/examples/run_tests.rs
@@ -1,12 +1,12 @@
 extern crate finchers;
 
 use finchers::Endpoint;
-use finchers::endpoint::{EndpointError, PathExt};
+use finchers::endpoint::{segment, EndpointError, PathExt};
 use finchers::endpoint::method::get;
 use finchers::test::{run_test, TestCase};
 
 fn main() {
-    let endpoint = || get("foo".with("bar").with(u64::PATH));
+    let endpoint = || get(segment("foo").with(segment("bar")).with(u64::PATH));
 
     let input = TestCase::get("/foo/bar/42");
     let output = run_test(endpoint(), input);

--- a/examples/run_tests.rs
+++ b/examples/run_tests.rs
@@ -1,12 +1,12 @@
 extern crate finchers;
 
 use finchers::Endpoint;
-use finchers::endpoint::{segment, EndpointError, PathExt};
+use finchers::endpoint::{param, segment, EndpointError};
 use finchers::endpoint::method::get;
 use finchers::test::{run_test, TestCase};
 
 fn main() {
-    let endpoint = || get(segment("foo").with(segment("bar")).with(u64::PATH));
+    let endpoint = || get(segment("foo").with(segment("bar")).with(param::<u64>()));
 
     let input = TestCase::get("/foo/bar/42");
     let output = run_test(endpoint(), input);

--- a/examples/techempower.rs
+++ b/examples/techempower.rs
@@ -4,6 +4,7 @@ extern crate num_cpus;
 extern crate serde_derive;
 
 use finchers::Endpoint;
+use finchers::endpoint::segment;
 use finchers::endpoint::method::get;
 use finchers::server::Server;
 use finchers::json::Json;
@@ -16,13 +17,13 @@ struct Message {
 
 fn main() {
     let endpoint = |_: &_| {
-        let json = get("json").map(|_| {
+        let json = get(segment("json")).map(|_| {
             Json(Message {
                 message: "Hello, World!",
             })
         });
 
-        let plaintext = get("plaintext").map(|_| "Hello, World!");
+        let plaintext = get(segment("plaintext")).map(|_| "Hello, World!");
 
         (json.map(Either2::E1)).or(plaintext.map(Either2::E2))
     };

--- a/examples/todo.rs
+++ b/examples/todo.rs
@@ -7,7 +7,7 @@ extern crate serde;
 extern crate serde_derive;
 
 use finchers::Endpoint;
-use finchers::endpoint::path::{segment, PathExt};
+use finchers::endpoint::path::{param, segment};
 use finchers::endpoint::method::{delete, get, post, put};
 use finchers::response::{Created, Responder, Response};
 use finchers::server::Server;
@@ -111,7 +111,11 @@ fn main() {
         use todo::{NewTodo, Todo};
 
         let todos = || segment("todos").map_err(|_| ApiError::Unknown);
-        let todos_id = || segment("todos").with(u64::PATH).map_err(|_| ApiError::Unknown);
+        let todos_id = || {
+            segment("todos")
+                .with(param::<u64>())
+                .map_err(|_| ApiError::Unknown)
+        };
 
         // GET /todos/:id
         let get_todo = get(todos_id()).map(|id| Json(todo::get(id)));

--- a/examples/todo.rs
+++ b/examples/todo.rs
@@ -7,8 +7,8 @@ extern crate serde;
 extern crate serde_derive;
 
 use finchers::Endpoint;
+use finchers::endpoint::path::{segment, PathExt};
 use finchers::endpoint::method::{delete, get, post, put};
-use finchers::endpoint::PathExt;
 use finchers::response::{Created, Responder, Response};
 use finchers::server::Server;
 use finchers::util::NoReturn;
@@ -110,8 +110,8 @@ fn main() {
     let endpoint = |_: &_| {
         use todo::{NewTodo, Todo};
 
-        let todos = || "todos".map_err(|_| ApiError::Unknown);
-        let todos_id = || "todos".with(u64::PATH).map_err(|_| ApiError::Unknown);
+        let todos = || segment("todos").map_err(|_| ApiError::Unknown);
+        let todos_id = || segment("todos").with(u64::PATH).map_err(|_| ApiError::Unknown);
 
         // GET /todos/:id
         let get_todo = get(todos_id()).map(|id| Json(todo::get(id)));

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -31,4 +31,5 @@ pub use self::header::{header, header_opt};
 pub use self::query::{query, query_opt};
 
 #[doc(inline)]
-pub use self::path::{path, path_seq, path_vec, segment, PathExt};
+#[allow(deprecated)]
+pub use self::path::{param, params, segment, PathExt};

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -31,4 +31,4 @@ pub use self::header::{header, header_opt};
 pub use self::query::{query, query_opt};
 
 #[doc(inline)]
-pub use self::path::{path, path_seq, path_vec, PathExt};
+pub use self::path::{path, path_seq, path_vec, segment, PathExt};

--- a/src/endpoint/path.rs
+++ b/src/endpoint/path.rs
@@ -37,17 +37,17 @@ pub fn segment<'a, T: 'a + Into<Cow<'a, str>>>(segment: T) -> PathSegment<'a> {
 
 #[allow(missing_docs)]
 #[derive(Debug)]
-pub struct Path<T>(PhantomData<fn(T) -> T>);
+pub struct PathParam<T>(PhantomData<fn() -> T>);
 
-impl<T> Copy for Path<T> {}
+impl<T> Copy for PathParam<T> {}
 
-impl<T> Clone for Path<T> {
-    fn clone(&self) -> Path<T> {
+impl<T> Clone for PathParam<T> {
+    fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<T: FromParam> Endpoint for Path<T> {
+impl<T: FromParam> Endpoint for PathParam<T> {
     type Item = T;
     type Error = NoReturn;
     type Future = FutureResult<Self::Item, Self::Error>;
@@ -61,24 +61,25 @@ impl<T: FromParam> Endpoint for Path<T> {
 }
 
 /// Create an endpoint which represents a path element
-pub fn path<T: FromParam>() -> Path<T> {
-    Path(PhantomData)
+pub fn param<T: FromParam>() -> PathParam<T> {
+    PathParam(PhantomData)
 }
 
 
 #[allow(missing_docs)]
 #[derive(Debug)]
-pub struct PathSeq<I, T>(PhantomData<fn() -> (I, T)>);
+pub struct PathParams<I, T>(PhantomData<fn() -> (I, T)>);
 
-impl<I, T> Clone for PathSeq<I, T> {
-    fn clone(&self) -> PathSeq<I, T> {
-        PathSeq(PhantomData)
+impl<I, T> Copy for PathParams<I, T> {}
+
+impl<I, T> Clone for PathParams<I, T> {
+    fn clone(&self) -> Self {
+        *self
     }
 }
 
-impl<I, T> Copy for PathSeq<I, T> {}
 
-impl<I, T> Endpoint for PathSeq<I, T>
+impl<I, T> Endpoint for PathParams<I, T>
 where
     I: FromIterator<T> + Default,
     T: FromParam,
@@ -97,27 +98,21 @@ where
 }
 
 /// Create an endpoint which represents the sequence of remaining path elements
-pub fn path_seq<I, T>() -> PathSeq<I, T>
+pub fn params<I, T>() -> PathParams<I, T>
 where
     I: FromIterator<T>,
     T: FromParam,
 {
-    PathSeq(PhantomData)
-}
-
-#[allow(missing_docs)]
-pub type PathVec<T> = PathSeq<Vec<T>, T>;
-
-/// Equivalent to `path_seq<Vec<T>, T>()`
-pub fn path_vec<T: FromParam>() -> PathVec<T> {
-    PathSeq(PhantomData)
+    PathParams(PhantomData)
 }
 
 
 #[allow(missing_docs)]
+#[deprecated(since = "0.6.0", note = "use param::<T>() instead")]
 pub trait PathExt: FromParam {
     /// equivalent to `path::<Self>()`
-    const PATH: Path<Self> = Path(PhantomData);
+    const PATH: PathParam<Self> = PathParam(PhantomData);
 }
 
+#[allow(deprecated)]
 impl<T: FromParam> PathExt for T {}


### PR DESCRIPTION
Other changes:
* The implementation of `Endpoint` for string types (`&str`, `String` and `Cow<str>`) is removed
* `path_vec<T>()` is removed
* The associated constant `PathExt::PATH` is now deprecated