### PR TITLE
Add a new trait `IntoEndpoint`

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,0 +1,18 @@
+extern crate finchers;
+
+use finchers::Endpoint;
+use finchers::endpoint::method::get;
+use finchers::endpoint::param;
+use finchers::ServerBuilder;
+
+fn main() {
+    // GET /foo/:id/bar
+    let endpoint = get(("foo", param(), "bar"))
+        .map(|(_, name, _)| name)
+        .and_then(|name: String| -> Result<_, ()> { Ok(format!("Hello, {}", name)) });
+
+    ServerBuilder::default()
+        .bind("0.0.0.0:8080")
+        .num_workers(1)
+        .run_http(endpoint);
+}

--- a/src/endpoint/combinator/and_then.rs
+++ b/src/endpoint/combinator/and_then.rs
@@ -2,19 +2,19 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use context::Context;
-use endpoint::{Endpoint, EndpointError};
+use endpoint::{Endpoint, EndpointError, IntoEndpoint};
 use task::{self, IntoTask};
 
 
 /// Equivalent to `e.and_then(f)`
-pub fn and_then<E, F, R>(endpoint: E, f: F) -> AndThen<E, F, R>
+pub fn and_then<E, F, R, A, B>(endpoint: E, f: F) -> AndThen<E::Endpoint, F, R>
 where
-    E: Endpoint,
-    F: Fn(E::Item) -> R,
-    R: IntoTask<Error = E::Error>,
+    E: IntoEndpoint<A, B>,
+    F: Fn(A) -> R,
+    R: IntoTask<Error = B>,
 {
     AndThen {
-        endpoint,
+        endpoint: endpoint.into_endpoint(),
         f: Arc::new(f),
         _marker: PhantomData,
     }

--- a/src/endpoint/combinator/from_err.rs
+++ b/src/endpoint/combinator/from_err.rs
@@ -3,17 +3,17 @@
 use std::marker::PhantomData;
 
 use context::Context;
-use endpoint::{Endpoint, EndpointError};
+use endpoint::{Endpoint, EndpointError, IntoEndpoint};
 use task;
 
 
-pub fn from_err<E, T>(endpoint: E) -> FromErr<E, T>
+pub fn from_err<E, T, A, B>(endpoint: E) -> FromErr<E::Endpoint, T>
 where
-    E: Endpoint,
-    T: From<E::Error>,
+    E: IntoEndpoint<A, B>,
+    T: From<B>,
 {
     FromErr {
-        endpoint,
+        endpoint: endpoint.into_endpoint(),
         _marker: PhantomData,
     }
 }

--- a/src/endpoint/combinator/inspect.rs
+++ b/src/endpoint/combinator/inspect.rs
@@ -3,17 +3,17 @@
 use std::sync::Arc;
 
 use context::Context;
-use endpoint::{Endpoint, EndpointError};
+use endpoint::{Endpoint, EndpointError, IntoEndpoint};
 use task;
 
 
-pub fn inspect<E, F>(endpoint: E, f: F) -> Inspect<E, F>
+pub fn inspect<E, F, A, B>(endpoint: E, f: F) -> Inspect<E::Endpoint, F>
 where
-    E: Endpoint,
-    F: Fn(&E::Item),
+    E: IntoEndpoint<A, B>,
+    F: Fn(&A),
 {
     Inspect {
-        endpoint,
+        endpoint: endpoint.into_endpoint(),
         f: Arc::new(f),
     }
 }

--- a/src/endpoint/combinator/join.rs
+++ b/src/endpoint/combinator/join.rs
@@ -1,42 +1,61 @@
 #![allow(missing_docs)]
+#![allow(non_snake_case)]
 
+use std::marker::PhantomData;
 use context::Context;
 use endpoint::{Endpoint, EndpointError};
 use task;
 
 
-// TODO: add Join3, Join4, Join5
+macro_rules! generate {
+    ($(
+        ($new:ident, $Join:ident, <$($T:ident),*>),
+    )*) => {$(
+        pub fn $new<$($T,)* E>($( $T: $T ),*) -> $Join <$($T,)* E>
+        where $(
+            $T: Endpoint<Error = E>,
+        )*
+        {
+            $Join {
+                $($T,)*
+                _marker: PhantomData,
+            }
+        }
 
-pub fn join<E1, E2>(e1: E1, e2: E2) -> Join<E1, E2>
-where
-    E1: Endpoint,
-    E2: Endpoint<Error = E1::Error>,
-{
-    Join { e1, e2 }
+        #[derive(Debug)]
+        pub struct $Join<$($T,)* E>
+        where $(
+            $T: Endpoint<Error = E>,
+        )* {
+            $(
+                $T: $T,
+            )*
+            _marker: PhantomData<E>,
+        }
+
+        impl<$($T,)* E> Endpoint for $Join<$($T,)* E>
+        where $(
+            $T: Endpoint<Error = E>,
+        )*
+        {
+            type Item = ($($T::Item),*);
+            type Error = E;
+            type Task = task::$Join<$($T::Task,)* E>;
+
+            fn apply(&self, ctx: &mut Context) -> Result<Self::Task, EndpointError> {
+                $(
+                    let $T = self.$T.apply(ctx)?;
+                )*
+                Ok(task::$new($($T),*))
+            }
+        }
+    )*};
 }
 
-#[derive(Debug)]
-pub struct Join<E1, E2>
-where
-    E1: Endpoint,
-    E2: Endpoint<Error = E1::Error>,
-{
-    e1: E1,
-    e2: E2,
-}
-
-impl<E1, E2> Endpoint for Join<E1, E2>
-where
-    E1: Endpoint,
-    E2: Endpoint<Error = E1::Error>,
-{
-    type Item = (E1::Item, E2::Item);
-    type Error = E1::Error;
-    type Task = task::Join<E1::Task, E2::Task>;
-
-    fn apply(&self, ctx: &mut Context) -> Result<Self::Task, EndpointError> {
-        let f1 = self.e1.apply(ctx)?;
-        let f2 = self.e2.apply(ctx)?;
-        Ok(task::join(f1, f2))
-    }
+generate! {
+    (join, Join, <E1, E2>),
+    (join3, Join3, <E1, E2, E3>),
+    (join4, Join4, <E1, E2, E3, E4>),
+    (join5, Join5, <E1, E2, E3, E4, E5>),
+    (join6, Join6, <E1, E2, E3, E4, E5, E6>),
 }

--- a/src/endpoint/combinator/map.rs
+++ b/src/endpoint/combinator/map.rs
@@ -2,18 +2,18 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use context::Context;
-use endpoint::{Endpoint, EndpointError};
+use endpoint::{Endpoint, EndpointError, IntoEndpoint};
 use task;
 
 
 /// Equivalent to `e.map(f)`
-pub fn map<E, F, R>(endpoint: E, f: F) -> Map<E, F, R>
+pub fn map<E, F, R, A, B>(endpoint: E, f: F) -> Map<E::Endpoint, F, R>
 where
-    E: Endpoint,
-    F: Fn(E::Item) -> R,
+    E: IntoEndpoint<A, B>,
+    F: Fn(A) -> R,
 {
     Map {
-        endpoint,
+        endpoint: endpoint.into_endpoint(),
         f: Arc::new(f),
         _marker: PhantomData,
     }

--- a/src/endpoint/combinator/map_err.rs
+++ b/src/endpoint/combinator/map_err.rs
@@ -2,18 +2,18 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use context::Context;
-use endpoint::{Endpoint, EndpointError};
+use endpoint::{Endpoint, EndpointError, IntoEndpoint};
 use task;
 
 
 /// Equivalent to `e.map_err(f)`
-pub fn map_err<E, F, R>(endpoint: E, f: F) -> MapErr<E, F, R>
+pub fn map_err<E, F, R, A, B>(endpoint: E, f: F) -> MapErr<E::Endpoint, F, R>
 where
-    E: Endpoint,
-    F: Fn(E::Error) -> R,
+    E: IntoEndpoint<A, B>,
+    F: Fn(B) -> R,
 {
     MapErr {
-        endpoint,
+        endpoint: endpoint.into_endpoint(),
         f: Arc::new(f),
         _marker: PhantomData,
     }

--- a/src/endpoint/combinator/mod.rs
+++ b/src/endpoint/combinator/mod.rs
@@ -15,7 +15,7 @@ mod with;
 pub use self::and_then::{and_then, AndThen};
 pub use self::from_err::{from_err, FromErr};
 pub use self::inspect::{inspect, Inspect};
-pub use self::join::{join, Join};
+pub use self::join::{join, Join, Join3, Join4, Join5, Join6, join3, join4, join5, join6};
 pub use self::map::{map, Map};
 pub use self::map_err::{map_err, MapErr};
 pub use self::or::{or, Or};

--- a/src/endpoint/combinator/or.rs
+++ b/src/endpoint/combinator/or.rs
@@ -1,15 +1,18 @@
 use context::Context;
-use endpoint::{Endpoint, EndpointError};
+use endpoint::{Endpoint, EndpointError, IntoEndpoint};
 use task;
 
 
 /// Equivalent to `e1.or(e2)`
-pub fn or<E1, E2>(e1: E1, e2: E2) -> Or<E1, E2>
+pub fn or<E1, E2, A, B>(e1: E1, e2: E2) -> Or<E1::Endpoint, E2::Endpoint>
 where
-    E1: Endpoint,
-    E2: Endpoint<Item = E1::Item, Error = E1::Error>,
+    E1: IntoEndpoint<A, B>,
+    E2: IntoEndpoint<A, B>,
 {
-    Or { e1, e2 }
+    Or {
+        e1: e1.into_endpoint(),
+        e2: e2.into_endpoint(),
+    }
 }
 
 

--- a/src/endpoint/combinator/or_else.rs
+++ b/src/endpoint/combinator/or_else.rs
@@ -2,19 +2,19 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use context::Context;
-use endpoint::{Endpoint, EndpointError};
+use endpoint::{Endpoint, EndpointError, IntoEndpoint};
 use task::{self, IntoTask};
 
 
 /// Equivalent to `e.or_else(f)`
-pub fn or_else<E, F, R>(endpoint: E, f: F) -> OrElse<E, F, R>
+pub fn or_else<E, F, R, A, B>(endpoint: E, f: F) -> OrElse<E::Endpoint, F, R>
 where
-    E: Endpoint,
-    F: Fn(E::Error) -> R,
-    R: IntoTask<Item = E::Item>,
+    E: IntoEndpoint<A, B>,
+    F: Fn(B) -> R,
+    R: IntoTask<Item = A>,
 {
     OrElse {
-        endpoint,
+        endpoint: endpoint.into_endpoint(),
         f: Arc::new(f),
         _marker: PhantomData,
     }

--- a/src/endpoint/combinator/skip.rs
+++ b/src/endpoint/combinator/skip.rs
@@ -1,15 +1,18 @@
 #![allow(missing_docs)]
 
 use context::Context;
-use endpoint::{Endpoint, EndpointError};
+use endpoint::{Endpoint, EndpointError, IntoEndpoint};
 
 
-pub fn skip<E1, E2>(e1: E1, e2: E2) -> Skip<E1, E2>
+pub fn skip<E1, E2, A, B, C>(e1: E1, e2: E2) -> Skip<E1::Endpoint, E2::Endpoint>
 where
-    E1: Endpoint,
-    E2: Endpoint<Error = E1::Error>,
+    E1: IntoEndpoint<A, B>,
+    E2: IntoEndpoint<C, B>,
 {
-    Skip { e1, e2 }
+    Skip {
+        e1: e1.into_endpoint(),
+        e2: e2.into_endpoint(),
+    }
 }
 
 #[derive(Debug)]

--- a/src/endpoint/combinator/then.rs
+++ b/src/endpoint/combinator/then.rs
@@ -2,19 +2,19 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use context::Context;
-use endpoint::{Endpoint, EndpointError};
+use endpoint::{Endpoint, EndpointError, IntoEndpoint};
 use task::{self, IntoTask};
 
 
 /// Equivalent to `e.then(f)`
-pub fn then<E, F, R>(endpoint: E, f: F) -> Then<E, F, R>
+pub fn then<E, F, R, A, B>(endpoint: E, f: F) -> Then<E::Endpoint, F, R>
 where
-    E: Endpoint,
-    F: Fn(Result<E::Item, E::Error>) -> R,
+    E: IntoEndpoint<A, B>,
+    F: Fn(Result<A, B>) -> R,
     R: IntoTask,
 {
     Then {
-        endpoint,
+        endpoint: endpoint.into_endpoint(),
         f: Arc::new(f),
         _marker: PhantomData,
     }

--- a/src/endpoint/combinator/with.rs
+++ b/src/endpoint/combinator/with.rs
@@ -1,14 +1,17 @@
 #![allow(missing_docs)]
 
 use context::Context;
-use endpoint::{Endpoint, EndpointError};
+use endpoint::{Endpoint, EndpointError, IntoEndpoint};
 
-pub fn with<E1, E2>(e1: E1, e2: E2) -> With<E1, E2>
+pub fn with<E1, E2, A, B, C>(e1: E1, e2: E2) -> With<E1::Endpoint, E2::Endpoint>
 where
-    E1: Endpoint,
-    E2: Endpoint<Error = E1::Error>,
+    E1: IntoEndpoint<A, B>,
+    E2: IntoEndpoint<C, B>,
 {
-    With { e1, e2 }
+    With {
+        e1: e1.into_endpoint(),
+        e2: e2.into_endpoint(),
+    }
 }
 
 #[derive(Debug)]

--- a/src/endpoint/endpoint.rs
+++ b/src/endpoint/endpoint.rs
@@ -43,12 +43,65 @@ pub trait Endpoint {
 
     /// Combine itself and the other endpoint, and create a combinator which returns a pair of its
     /// `Item`s.
-    fn join<E>(self, e: E) -> Join<Self, E>
+    fn join<E>(self, e: E) -> Join<Self, E, Self::Error>
     where
         Self: Sized,
         E: Endpoint<Error = Self::Error>,
     {
         join(self, e)
+    }
+
+    #[allow(missing_docs)]
+    fn join3<E1, E2>(self, e1: E1, e2: E2) -> Join3<Self, E1, E2, Self::Error>
+    where
+        Self: Sized,
+        E1: Endpoint<Error = Self::Error>,
+        E2: Endpoint<Error = Self::Error>,
+    {
+        join3(self, e1, e2)
+    }
+
+    #[allow(missing_docs)]
+    fn join4<E1, E2, E3>(self, e1: E1, e2: E2, e3: E3) -> Join4<Self, E1, E2, E3, Self::Error>
+    where
+        Self: Sized,
+        E1: Endpoint<Error = Self::Error>,
+        E2: Endpoint<Error = Self::Error>,
+        E3: Endpoint<Error = Self::Error>,
+    {
+        join4(self, e1, e2, e3)
+    }
+
+    #[allow(missing_docs)]
+    fn join5<E1, E2, E3, E4>(self, e1: E1, e2: E2, e3: E3, e4: E4) -> Join5<Self, E1, E2, E3, E4, Self::Error>
+    where
+        Self: Sized,
+        E1: Endpoint<Error = Self::Error>,
+        E2: Endpoint<Error = Self::Error>,
+        E3: Endpoint<Error = Self::Error>,
+        E4: Endpoint<Error = Self::Error>,
+    {
+        join5(self, e1, e2, e3, e4)
+    }
+
+    #[allow(missing_docs)]
+    fn join6<E1, E2, E3, E4, E5>(
+        self,
+        e1: E1,
+        e2: E2,
+        e3: E3,
+        e4: E4,
+        e5: E5,
+    ) -> Join6<Self, E1, E2, E3, E4, E5, Self::Error>
+    where
+        Self: Sized,
+        E1: Endpoint<Error = Self::Error>,
+        E2: Endpoint<Error = Self::Error>,
+        E3: Endpoint<Error = Self::Error>,
+        E4: Endpoint<Error = Self::Error>,
+        E5: Endpoint<Error = Self::Error>,
+    {
+        join6(self, e1, e2, e3, e4, e5)
     }
 
     /// Combine itself and the other endpoint, and create a combinator which returns `E::Item`.

--- a/src/endpoint/endpoint.rs
+++ b/src/endpoint/endpoint.rs
@@ -237,3 +237,22 @@ impl<E: Endpoint> Endpoint for Arc<E> {
         (**self).apply(ctx)
     }
 }
+
+
+#[allow(missing_docs)]
+pub trait IntoEndpoint<T, E> {
+    type Endpoint: Endpoint<Item = T, Error = E>;
+
+    fn into_endpoint(self) -> Self::Endpoint;
+}
+
+impl<E, A, B> IntoEndpoint<A, B> for E
+where
+    E: Endpoint<Item = A, Error = B>,
+{
+    type Endpoint = E;
+
+    fn into_endpoint(self) -> Self::Endpoint {
+        self
+    }
+}

--- a/src/endpoint/method.rs
+++ b/src/endpoint/method.rs
@@ -3,7 +3,7 @@
 use hyper::Method;
 
 use context::Context;
-use endpoint::{Endpoint, EndpointError};
+use endpoint::{Endpoint, EndpointError, IntoEndpoint};
 
 #[allow(missing_docs)]
 #[derive(Debug, Clone)]
@@ -28,36 +28,51 @@ impl<E: Endpoint> Endpoint for MatchMethod<E> {
 
 /// Wrap given endpoint with additional check of HTTP method,
 /// successes only if its method is `GET`.
-pub fn get<E: Endpoint>(endpoint: E) -> MatchMethod<E> {
-    MatchMethod(Method::Get, endpoint)
+pub fn get<E, A, B>(endpoint: E) -> MatchMethod<E::Endpoint>
+where
+    E: IntoEndpoint<A, B>,
+{
+    MatchMethod(Method::Get, endpoint.into_endpoint())
 }
 
 /// Wrap given endpoint with additional check of HTTP method,
 /// successes only if its method is `POST`.
-pub fn post<E: Endpoint>(endpoint: E) -> MatchMethod<E> {
-    MatchMethod(Method::Post, endpoint)
+pub fn post<E, A, B>(endpoint: E) -> MatchMethod<E::Endpoint>
+where
+    E: IntoEndpoint<A, B>,
+{
+    MatchMethod(Method::Post, endpoint.into_endpoint())
 }
 
 /// Wrap given endpoint with additional check of HTTP method,
 /// successes only if its method is `PUT`.
-pub fn put<E: Endpoint>(endpoint: E) -> MatchMethod<E> {
-    MatchMethod(Method::Put, endpoint)
+pub fn put<E, A, B>(endpoint: E) -> MatchMethod<E::Endpoint>
+where
+    E: IntoEndpoint<A, B>,
+{
+    MatchMethod(Method::Put, endpoint.into_endpoint())
 }
 
 /// Wrap given endpoint with additional check of HTTP method,
 /// successes only if its method is `DELETE`.
-pub fn delete<E: Endpoint>(endpoint: E) -> MatchMethod<E> {
-    MatchMethod(Method::Delete, endpoint)
+pub fn delete<E, A, B>(endpoint: E) -> MatchMethod<E::Endpoint>
+where
+    E: IntoEndpoint<A, B>,
+{
+    MatchMethod(Method::Delete, endpoint.into_endpoint())
 }
 
 /// Wrap given endpoint with additional check of HTTP method,
 /// successes only if its method is `HEAD`.
-pub fn head<E: Endpoint>(endpoint: E) -> MatchMethod<E> {
-    MatchMethod(Method::Head, endpoint)
+pub fn head<E, A, B>(endpoint: E) -> MatchMethod<E::Endpoint>
+where
+    E: IntoEndpoint<A, B>,
+{
+    MatchMethod(Method::Head, endpoint.into_endpoint())
 }
 
 /// Wrap given endpoint with additional check of HTTP method,
 /// successes only if its method is `PATCH`.
 pub fn patch<E: Endpoint>(endpoint: E) -> MatchMethod<E> {
-    MatchMethod(Method::Patch, endpoint)
+    MatchMethod(Method::Patch, endpoint.into_endpoint())
 }

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -11,7 +11,7 @@ pub mod query;
 
 // re-exports
 #[doc(inline)]
-pub use self::endpoint::{Endpoint, EndpointError};
+pub use self::endpoint::{Endpoint, EndpointError, IntoEndpoint};
 
 #[doc(inline)]
 pub use self::body::body;

--- a/src/endpoint/path.rs
+++ b/src/endpoint/path.rs
@@ -5,7 +5,7 @@ use std::iter::FromIterator;
 use std::marker::PhantomData;
 
 use context::Context;
-use endpoint::{Endpoint, EndpointError};
+use endpoint::{Endpoint, EndpointError, IntoEndpoint};
 use request::FromParam;
 use task::{ok, TaskResult};
 
@@ -24,6 +24,27 @@ impl<'a, E> Endpoint for PathSegment<'a, E> {
             return Err(EndpointError::Skipped);
         }
         Ok(ok(()))
+    }
+}
+
+impl<'a, E> IntoEndpoint<(), E> for &'a str {
+    type Endpoint = PathSegment<'a, E>;
+    fn into_endpoint(self) -> Self::Endpoint {
+        segment(self)
+    }
+}
+
+impl<E> IntoEndpoint<(), E> for String {
+    type Endpoint = PathSegment<'static, E>;
+    fn into_endpoint(self) -> Self::Endpoint {
+        segment(self)
+    }
+}
+
+impl<'a, E> IntoEndpoint<(), E> for Cow<'a, str> {
+    type Endpoint = PathSegment<'a, E>;
+    fn into_endpoint(self) -> Self::Endpoint {
+        segment(self)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,13 +27,13 @@ mod context;
 pub use context::Context;
 
 #[doc(inline)]
-pub use endpoint::Endpoint;
+pub use endpoint::{Endpoint, IntoEndpoint};
 
 #[doc(inline)]
 pub use request::Request;
 
 #[doc(inline)]
-pub use response::{Responder, Response};
+pub use response::{IntoResponder, Responder, Response};
 
 #[doc(inline)]
 pub use server::ServerBuilder;

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -22,7 +22,7 @@ pub use self::and_then::{and_then, AndThen};
 pub use self::from_err::{from_err, FromErr};
 pub use self::futures::{future, TaskFuture};
 pub use self::inspect::{inspect, Inspect};
-pub use self::join::{join, Join};
+pub use self::join::{join, Join, Join3, Join4, Join5, Join6, join3, join4, join5, join6};
 pub use self::map_err::{map_err, MapErr};
 pub use self::map::{map, Map};
 pub use self::or_else::{or_else, OrElse};


### PR DESCRIPTION
It helps to compose the endpoint without redundant descriptions.

```rust
let endpoint = get(segment("foo").join(segment("bar")));
```

will be

```rust
let endpoint = get(("foo", "bar"));
```