### PR TITLE
change the return type of Endpoint::apply

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -2,17 +2,19 @@
 extern crate error_chain;
 extern crate finchers;
 
-use std::string::FromUtf8Error;
-use finchers::{Endpoint, EndpointError};
+use std::string::{FromUtf8Error, ParseError};
+use finchers::Endpoint;
 use finchers::endpoint::method::{get, post};
 use finchers::endpoint::{body, path};
 use finchers::request::BodyError;
 use finchers::response::{Responder, ResponderContext, Response, ResponseBuilder, StatusCode};
 use finchers::ServerBuilder;
+use finchers::server::NotFound;
 
 error_chain! {
     foreign_links {
-        Endpoint(EndpointError);
+        NotFound(NotFound);
+        ParsePath(ParseError);
         BodyRecv(BodyError);
         FromUtf8(FromUtf8Error);
     }
@@ -28,8 +30,7 @@ impl Responder for Error {
 
 fn main() {
     // GET /foo/:id
-    let endpoint1 = get(("foo", path()))
-        .and_then(|(_, name): (_, String)| Ok(format!("Hello, {}", name)));
+    let endpoint1 = get(("foo", path())).and_then(|(_, name): (_, String)| Ok(format!("Hello, {}", name)));
 
     // POST /foo/:id [String] (Content-type: text/plain; charset=utf-8)
     let endpoint2 = post(("foo", path(), body()))

--- a/src/endpoint/and_then.rs
+++ b/src/endpoint/and_then.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use endpoint::{Endpoint, EndpointContext, EndpointError, IntoEndpoint};
+use endpoint::{Endpoint, EndpointContext, IntoEndpoint};
 use task::{self, IntoTask};
 
 
@@ -43,8 +43,8 @@ where
     type Error = R::Error;
     type Task = task::AndThen<E::Task, fn(E::Item) -> R, F, R>;
 
-    fn apply(&self, ctx: &mut EndpointContext) -> Result<Self::Task, EndpointError> {
+    fn apply(&self, ctx: &mut EndpointContext) -> Option<Self::Task> {
         let f = self.endpoint.apply(ctx)?;
-        Ok(task::and_then_shared(f, self.f.clone()))
+        Some(task::and_then_shared(f, self.f.clone()))
     }
 }

--- a/src/endpoint/apply_fn.rs
+++ b/src/endpoint/apply_fn.rs
@@ -2,12 +2,12 @@
 
 use std::marker::PhantomData;
 use std::sync::Arc;
-use super::{Endpoint, EndpointContext, EndpointError};
+use super::{Endpoint, EndpointContext};
 use task::IntoTask;
 
 pub fn apply_fn<F, T>(f: F) -> ApplyFn<F, T>
 where
-    F: Fn(&mut EndpointContext) -> Result<T, EndpointError>,
+    F: Fn(&mut EndpointContext) -> Option<T>,
     T: IntoTask,
 {
     ApplyFn {
@@ -19,7 +19,7 @@ where
 #[derive(Debug)]
 pub struct ApplyFn<F, T>
 where
-    F: Fn(&mut EndpointContext) -> Result<T, EndpointError>,
+    F: Fn(&mut EndpointContext) -> Option<T>,
     T: IntoTask,
 {
     f: Arc<F>,
@@ -28,14 +28,14 @@ where
 
 impl<F, T> Endpoint for ApplyFn<F, T>
 where
-    F: Fn(&mut EndpointContext) -> Result<T, EndpointError>,
+    F: Fn(&mut EndpointContext) -> Option<T>,
     T: IntoTask,
 {
     type Item = T::Item;
     type Error = T::Error;
     type Task = T::Task;
 
-    fn apply(&self, ctx: &mut EndpointContext) -> Result<Self::Task, EndpointError> {
+    fn apply(&self, ctx: &mut EndpointContext) -> Option<Self::Task> {
         (*self.f)(ctx).map(IntoTask::into_task)
     }
 }

--- a/src/endpoint/body.rs
+++ b/src/endpoint/body.rs
@@ -2,7 +2,7 @@
 
 use std::marker::PhantomData;
 
-use endpoint::{Endpoint, EndpointContext, EndpointError};
+use endpoint::{Endpoint, EndpointContext};
 use request::{BodyError, FromBody};
 use task;
 
@@ -42,10 +42,10 @@ where
     type Error = E;
     type Task = task::Body<T, E>;
 
-    fn apply(&self, ctx: &mut EndpointContext) -> Result<Self::Task, EndpointError> {
+    fn apply(&self, ctx: &mut EndpointContext) -> Option<Self::Task> {
         match T::check_request(ctx.request()) {
-            true => Ok(task::Body::default()),
-            false => Err(EndpointError::Skipped),
+            true => Some(task::Body::default()),
+            false => None,
         }
     }
 }

--- a/src/endpoint/from_err.rs
+++ b/src/endpoint/from_err.rs
@@ -2,7 +2,7 @@
 
 use std::marker::PhantomData;
 
-use endpoint::{Endpoint, EndpointContext, EndpointError, IntoEndpoint};
+use endpoint::{Endpoint, EndpointContext, IntoEndpoint};
 use task;
 
 
@@ -37,8 +37,7 @@ where
     type Error = T;
     type Task = task::FromErr<E::Task, T>;
 
-    fn apply(&self, ctx: &mut EndpointContext) -> Result<Self::Task, EndpointError> {
-        let inner = self.endpoint.apply(ctx)?;
-        Ok(task::from_err(inner))
+    fn apply(&self, ctx: &mut EndpointContext) -> Option<Self::Task> {
+        self.endpoint.apply(ctx).map(task::from_err)
     }
 }

--- a/src/endpoint/inspect.rs
+++ b/src/endpoint/inspect.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use endpoint::{Endpoint, EndpointContext, EndpointError, IntoEndpoint};
+use endpoint::{Endpoint, EndpointContext, IntoEndpoint};
 use task;
 
 
@@ -37,8 +37,8 @@ where
     type Error = E::Error;
     type Task = task::Inspect<E::Task, fn(&E::Item), F>;
 
-    fn apply(&self, ctx: &mut EndpointContext) -> Result<Self::Task, EndpointError> {
+    fn apply(&self, ctx: &mut EndpointContext) -> Option<Self::Task> {
         let inner = self.endpoint.apply(ctx)?;
-        Ok(task::inspect_shared(inner, self.f.clone()))
+        Some(task::inspect_shared(inner, self.f.clone()))
     }
 }

--- a/src/endpoint/join.rs
+++ b/src/endpoint/join.rs
@@ -2,7 +2,7 @@
 #![allow(non_snake_case)]
 
 use std::marker::PhantomData;
-use endpoint::{Endpoint, EndpointContext, EndpointError, IntoEndpoint};
+use endpoint::{Endpoint, EndpointContext, IntoEndpoint};
 use task;
 
 
@@ -41,11 +41,11 @@ macro_rules! generate {
             type Error = E;
             type Task = task::$Join<$($T::Task,)* E>;
 
-            fn apply(&self, ctx: &mut EndpointContext) -> Result<Self::Task, EndpointError> {
+            fn apply(&self, ctx: &mut EndpointContext) -> Option<Self::Task> {
                 $(
                     let $T = self.$T.apply(ctx)?;
                 )*
-                Ok(task::$new($($T),*))
+                Some(task::$new($($T),*))
             }
         }
 

--- a/src/endpoint/join_all.rs
+++ b/src/endpoint/join_all.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 
 use task;
-use endpoint::{Endpoint, EndpointContext, EndpointError, IntoEndpoint};
+use endpoint::{Endpoint, EndpointContext, IntoEndpoint};
 
 
 pub fn join_all<I, E, A, B>(iter: I) -> JoinAll<E::Endpoint>
@@ -25,11 +25,11 @@ impl<E: Endpoint> Endpoint for JoinAll<E> {
     type Error = E::Error;
     type Task = task::JoinAll<E::Task>;
 
-    fn apply(&self, ctx: &mut EndpointContext) -> Result<Self::Task, EndpointError> {
+    fn apply(&self, ctx: &mut EndpointContext) -> Option<Self::Task> {
         let tasks: Vec<_> = self.inner
             .iter()
             .map(|e| e.apply(ctx))
-            .collect::<Result<_, EndpointError>>()?;
-        Ok(task::join_all(tasks))
+            .collect::<Option<_>>()?;
+        Some(task::join_all(tasks))
     }
 }

--- a/src/endpoint/map.rs
+++ b/src/endpoint/map.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use endpoint::{Endpoint, EndpointContext, EndpointError, IntoEndpoint};
+use endpoint::{Endpoint, EndpointContext, IntoEndpoint};
 use task;
 
 
@@ -40,8 +40,8 @@ where
     type Error = E::Error;
     type Task = task::Map<E::Task, fn(E::Item) -> R, F>;
 
-    fn apply(&self, ctx: &mut EndpointContext) -> Result<Self::Task, EndpointError> {
+    fn apply(&self, ctx: &mut EndpointContext) -> Option<Self::Task> {
         let inner = self.endpoint.apply(ctx)?;
-        Ok(task::map_shared(inner, self.f.clone()))
+        Some(task::map_shared(inner, self.f.clone()))
     }
 }

--- a/src/endpoint/map_err.rs
+++ b/src/endpoint/map_err.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use endpoint::{Endpoint, EndpointContext, EndpointError, IntoEndpoint};
+use endpoint::{Endpoint, EndpointContext, IntoEndpoint};
 use task;
 
 
@@ -40,8 +40,8 @@ where
     type Error = R;
     type Task = task::MapErr<E::Task, fn(E::Error) -> R, F>;
 
-    fn apply(&self, ctx: &mut EndpointContext) -> Result<Self::Task, EndpointError> {
+    fn apply(&self, ctx: &mut EndpointContext) -> Option<Self::Task> {
         let inner = self.endpoint.apply(ctx)?;
-        Ok(task::map_err_shared(inner, self.f.clone()))
+        Some(task::map_err_shared(inner, self.f.clone()))
     }
 }

--- a/src/endpoint/method.rs
+++ b/src/endpoint/method.rs
@@ -2,7 +2,7 @@
 
 use hyper::Method;
 
-use endpoint::{Endpoint, EndpointContext, EndpointError, IntoEndpoint};
+use endpoint::{Endpoint, EndpointContext, IntoEndpoint};
 
 #[allow(missing_docs)]
 #[derive(Debug, Clone)]
@@ -13,15 +13,15 @@ impl<E: Endpoint> Endpoint for MatchMethod<E> {
     type Error = E::Error;
     type Task = E::Task;
 
-    fn apply(&self, ctx: &mut EndpointContext) -> Result<Self::Task, EndpointError> {
+    fn apply(&self, ctx: &mut EndpointContext) -> Option<Self::Task> {
         let f = self.1.apply(ctx)?;
         if ctx.take_segments().map_or(0, |s| s.count()) > 0 {
-            return Err(EndpointError::Skipped);
+            return None;
         }
         if *ctx.request().method() != self.0 {
-            return Err(EndpointError::InvalidMethod);
+            return None;
         }
-        Ok(f)
+        Some(f)
     }
 }
 

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -28,7 +28,7 @@ mod with;
 pub use self::apply_fn::{apply_fn, ApplyFn};
 pub use self::body::body;
 pub use self::context::{EndpointContext, Segments};
-pub use self::endpoint::{Endpoint, EndpointError, IntoEndpoint};
+pub use self::endpoint::{Endpoint, IntoEndpoint};
 pub use self::header::{header, header_opt};
 pub use self::method::MatchMethod;
 pub use self::path::{path, paths};

--- a/src/endpoint/or.rs
+++ b/src/endpoint/or.rs
@@ -1,4 +1,4 @@
-use endpoint::{Endpoint, EndpointContext, EndpointError, IntoEndpoint};
+use endpoint::{Endpoint, EndpointContext, IntoEndpoint};
 use task::{Poll, Task, TaskContext};
 
 
@@ -31,23 +31,23 @@ where
     type Error = E1::Error;
     type Task = OrTask<E1::Task, E2::Task>;
 
-    fn apply(&self, ctx: &mut EndpointContext) -> Result<Self::Task, EndpointError> {
+    fn apply(&self, ctx: &mut EndpointContext) -> Option<Self::Task> {
         let mut ctx1 = ctx.clone();
         match self.e1.apply(&mut ctx1) {
-            Ok(fut) => {
+            Some(fut) => {
                 *ctx = ctx1;
-                return Ok(OrTask {
+                return Some(OrTask {
                     inner: Either::Left(fut),
                 });
             }
-            Err(..) => {}
+            None => {}
         }
 
         match self.e2.apply(ctx) {
-            Ok(fut) => Ok(OrTask {
+            Some(fut) => Some(OrTask {
                 inner: Either::Right(fut),
             }),
-            Err(err) => Err(err),
+            None => None,
         }
     }
 }

--- a/src/endpoint/or_else.rs
+++ b/src/endpoint/or_else.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use endpoint::{Endpoint, EndpointContext, EndpointError, IntoEndpoint};
+use endpoint::{Endpoint, EndpointContext, IntoEndpoint};
 use task::{self, IntoTask};
 
 
@@ -43,8 +43,8 @@ where
     type Error = R::Error;
     type Task = task::OrElse<E::Task, fn(E::Error) -> R, F, R>;
 
-    fn apply(&self, ctx: &mut EndpointContext) -> Result<Self::Task, EndpointError> {
+    fn apply(&self, ctx: &mut EndpointContext) -> Option<Self::Task> {
         let task = self.endpoint.apply(ctx)?;
-        Ok(task::or_else_shared(task, self.f.clone()))
+        Some(task::or_else_shared(task, self.f.clone()))
     }
 }

--- a/src/endpoint/result.rs
+++ b/src/endpoint/result.rs
@@ -2,7 +2,7 @@
 
 use std::marker::PhantomData;
 use task::{self, TaskResult};
-use super::{Endpoint, EndpointContext, EndpointError};
+use super::{Endpoint, EndpointContext};
 
 
 pub fn ok<T: Clone, E>(x: T) -> EndpointOk<T, E> {
@@ -23,8 +23,8 @@ impl<T: Clone, E> Endpoint for EndpointOk<T, E> {
     type Error = E;
     type Task = TaskResult<T, E>;
 
-    fn apply(&self, _: &mut EndpointContext) -> Result<Self::Task, EndpointError> {
-        Ok(task::ok(self.x.clone()))
+    fn apply(&self, _: &mut EndpointContext) -> Option<Self::Task> {
+        Some(task::ok(self.x.clone()))
     }
 }
 
@@ -47,8 +47,8 @@ impl<T, E: Clone> Endpoint for EndpointErr<T, E> {
     type Error = E;
     type Task = TaskResult<T, E>;
 
-    fn apply(&self, _: &mut EndpointContext) -> Result<Self::Task, EndpointError> {
-        Ok(task::err(self.x.clone()))
+    fn apply(&self, _: &mut EndpointContext) -> Option<Self::Task> {
+        Some(task::err(self.x.clone()))
     }
 }
 
@@ -68,7 +68,7 @@ impl<T: Clone, E: Clone> Endpoint for EndpointResult<T, E> {
     type Error = E;
     type Task = TaskResult<T, E>;
 
-    fn apply(&self, _: &mut EndpointContext) -> Result<Self::Task, EndpointError> {
-        Ok(task::result(self.x.clone()))
+    fn apply(&self, _: &mut EndpointContext) -> Option<Self::Task> {
+        Some(task::result(self.x.clone()))
     }
 }

--- a/src/endpoint/skip.rs
+++ b/src/endpoint/skip.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 
-use endpoint::{Endpoint, EndpointContext, EndpointError, IntoEndpoint};
+use endpoint::{Endpoint, EndpointContext, IntoEndpoint};
 
 
 pub fn skip<E1, E2, A, B, C>(e1: E1, e2: E2) -> Skip<E1::Endpoint, E2::Endpoint>
@@ -33,9 +33,9 @@ where
     type Error = E1::Error;
     type Task = E1::Task;
 
-    fn apply(&self, ctx: &mut EndpointContext) -> Result<Self::Task, EndpointError> {
+    fn apply(&self, ctx: &mut EndpointContext) -> Option<Self::Task> {
         let f1 = self.e1.apply(ctx)?;
         let _f2 = self.e2.apply(ctx)?;
-        Ok(f1)
+        Some(f1)
     }
 }

--- a/src/endpoint/skip_all.rs
+++ b/src/endpoint/skip_all.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 
 use task::{self, TaskResult};
-use super::super::{Endpoint, EndpointContext, EndpointError, IntoEndpoint};
+use super::super::{Endpoint, EndpointContext, IntoEndpoint};
 
 pub fn skip_all<I, E, A, B>(iter: I) -> SkipAll<E::Endpoint>
 where
@@ -23,10 +23,10 @@ impl<E: Endpoint> Endpoint for SkipAll<E> {
     type Error = E::Error;
     type Task = TaskResult<(), E::Error>;
 
-    fn apply(&self, ctx: &mut EndpointContext) -> Result<Self::Task, EndpointError> {
+    fn apply(&self, ctx: &mut EndpointContext) -> Option<Self::Task> {
         for endpoint in &self.endpoints {
             let _ = endpoint.apply(ctx)?;
         }
-        Ok(task::ok(()))
+        Some(task::ok(()))
     }
 }

--- a/src/endpoint/then.rs
+++ b/src/endpoint/then.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use endpoint::{Endpoint, EndpointContext, EndpointError, IntoEndpoint};
+use endpoint::{Endpoint, EndpointContext, IntoEndpoint};
 use task::{self, IntoTask};
 
 
@@ -43,8 +43,8 @@ where
     type Error = R::Error;
     type Task = task::Then<E::Task, fn(Result<E::Item, E::Error>) -> R, F, R>;
 
-    fn apply(&self, ctx: &mut EndpointContext) -> Result<Self::Task, EndpointError> {
+    fn apply(&self, ctx: &mut EndpointContext) -> Option<Self::Task> {
         let fut = self.endpoint.apply(ctx)?;
-        Ok(task::then_shared(fut, self.f.clone()))
+        Some(task::then_shared(fut, self.f.clone()))
     }
 }

--- a/src/endpoint/with.rs
+++ b/src/endpoint/with.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 
-use endpoint::{Endpoint, EndpointContext, EndpointError, IntoEndpoint};
+use endpoint::{Endpoint, EndpointContext, IntoEndpoint};
 
 pub fn with<E1, E2, A, B, C>(e1: E1, e2: E2) -> With<E1::Endpoint, E2::Endpoint>
 where
@@ -32,9 +32,9 @@ where
     type Error = E2::Error;
     type Task = E2::Task;
 
-    fn apply(&self, ctx: &mut EndpointContext) -> Result<Self::Task, EndpointError> {
+    fn apply(&self, ctx: &mut EndpointContext) -> Option<Self::Task> {
         let _f1 = self.e1.apply(ctx)?;
         let f2 = self.e2.apply(ctx)?;
-        Ok(f2)
+        Some(f2)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub mod util;
 
 
 #[doc(inline)]
-pub use endpoint::{Endpoint, EndpointContext, EndpointError, IntoEndpoint};
+pub use endpoint::{Endpoint, EndpointContext, IntoEndpoint};
 
 #[doc(inline)]
 pub use request::Request;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,8 @@
 //! Definition of HTTP services for Hyper
 
 use std::borrow::Cow;
+use std::error;
+use std::fmt;
 use std::io;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -21,6 +23,18 @@ use service::EndpointService;
 #[allow(missing_docs)]
 #[derive(Debug)]
 pub struct NotFound;
+
+impl fmt::Display for NotFound {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("not found")
+    }
+}
+
+impl error::Error for NotFound {
+    fn description(&self) -> &str {
+        "not found"
+    }
+}
 
 
 /// The factory of HTTP service

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,9 +13,14 @@ use net2::TcpBuilder;
 use tokio_core::net::TcpListener;
 use tokio_core::reactor::{Core, Handle};
 
-use endpoint::{Endpoint, EndpointError};
+use endpoint::Endpoint;
 use response::IntoResponder;
 use service::EndpointService;
+
+
+#[allow(missing_docs)]
+#[derive(Debug)]
+pub struct NotFound;
 
 
 /// The factory of HTTP service
@@ -52,7 +57,7 @@ impl ServerBuilder {
     where
         E: Endpoint + Send + Sync + 'static,
         E::Item: IntoResponder,
-        E::Error: IntoResponder + From<EndpointError>,
+        E::Error: IntoResponder + From<NotFound>,
     {
         let endpoint = Arc::new(endpoint);
         let proto = Http::new();
@@ -86,7 +91,7 @@ struct Worker<'a, E>
 where
     E: Endpoint + Clone + 'static,
     E::Item: IntoResponder,
-    E::Error: IntoResponder + From<EndpointError>,
+    E::Error: IntoResponder + From<NotFound>,
 {
     endpoint: E,
     proto: Http<Chunk>,
@@ -98,7 +103,7 @@ impl<'a, E> Worker<'a, E>
 where
     E: Endpoint + Clone + 'static,
     E::Item: IntoResponder,
-    E::Error: IntoResponder + From<EndpointError>,
+    E::Error: IntoResponder + From<NotFound>,
 {
     fn run(&self) -> io::Result<()> {
         let mut core = Core::new()?;

--- a/src/test.rs
+++ b/src/test.rs
@@ -5,7 +5,7 @@ use hyper::Method;
 use hyper::header::Header;
 use tokio_core::reactor::Core;
 
-use endpoint::{Endpoint, EndpointContext, EndpointError};
+use endpoint::{Endpoint, EndpointContext};
 use request::{Body, Request};
 use task::{Task, TaskContext};
 
@@ -67,7 +67,7 @@ impl TestCase {
 
 
 /// Invoke given endpoint and return its result
-pub fn run_test<T, E>(endpoint: T, input: TestCase) -> Result<Result<E::Item, E::Error>, EndpointError>
+pub fn run_test<T, E>(endpoint: T, input: TestCase) -> Option<Result<E::Item, E::Error>>
 where
     T: AsRef<E>,
     E: Endpoint,
@@ -81,7 +81,7 @@ where
         endpoint.as_ref().apply(&mut ctx)?
     };
 
-    Ok(core.run(TestFuture {
+    Some(core.run(TestFuture {
         task,
         ctx: TaskContext::new(request, body.unwrap_or_default()),
     }))


### PR DESCRIPTION
The method `Endpoint::apply` returns an `Option<Self::Task>` rather than `Result<Self::Task, EndpointError>`.  The error variants of `EndpointError` has been moved to the independent error types and passed to `Task::Error`.

fixes #44 