### PR TITLE
Improvement the routing APIs

### DIFF
--- a/src/endpoint/context.rs
+++ b/src/endpoint/context.rs
@@ -1,3 +1,4 @@
+use std::ops::Deref;
 use http::{Cookies, Request};
 
 /// An iterator of remaning path segments.
@@ -5,39 +6,111 @@ use http::{Cookies, Request};
 pub struct Segments<'a> {
     path: &'a str,
     pos: usize,
+    popped: usize,
 }
 
 impl<'a> From<&'a str> for Segments<'a> {
     fn from(path: &'a str) -> Self {
         debug_assert!(!path.is_empty());
         debug_assert_eq!(path.chars().next(), Some('/'));
-        Segments { path, pos: 1 }
+        Segments {
+            path,
+            pos: 1,
+            popped: 0,
+        }
     }
 }
 
 impl<'a> Segments<'a> {
     /// Returns the remaining path in this segments
-    pub fn as_str(&self) -> &'a str {
+    #[inline]
+    pub fn remaining_path(&self) -> &'a str {
         &self.path[self.pos..]
+    }
+
+    /// Returns the cursor position in the original path
+    #[inline]
+    pub fn position(&self) -> usize {
+        self.pos
+    }
+
+    /// Returns the number of segments already popped
+    #[inline]
+    pub fn popped(&self) -> usize {
+        self.popped
     }
 }
 
 impl<'a> Iterator for Segments<'a> {
-    type Item = &'a str;
+    type Item = Segment<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.pos == self.path.len() {
             return None;
         }
         if let Some(offset) = self.path[self.pos..].find('/') {
-            let segment = &self.path[self.pos..self.pos + offset];
+            let segment = Segment {
+                s: &self.path[self.pos..self.pos + offset],
+                start: self.pos,
+                end: self.pos + offset,
+            };
             self.pos += offset + 1;
+            self.popped += 1;
             Some(segment)
         } else {
-            let segment = &self.path[self.pos..];
+            let segment = Segment {
+                s: &self.path[self.pos..],
+                start: self.pos,
+                end: self.path.len(),
+            };
             self.pos = self.path.len();
+            self.popped += 1;
             Some(segment)
         }
+    }
+}
+
+/// The type of returned value of `Segments::next()`
+#[derive(Debug)]
+pub struct Segment<'a> {
+    s: &'a str,
+    start: usize,
+    end: usize,
+}
+
+impl<'a> Segment<'a> {
+    /// Yields the underlying `str` slice.
+    #[inline]
+    pub fn as_str(&self) -> &'a str {
+        self.s
+    }
+
+    /// Returns the start position of this segment in the original path
+    #[inline]
+    pub fn start(&self) -> usize {
+        self.start
+    }
+
+    /// Returns the end position of this segment in the original path
+    #[inline]
+    pub fn end(&self) -> usize {
+        self.end
+    }
+}
+
+impl<'a> AsRef<str> for Segment<'a> {
+    #[inline]
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl<'a> Deref for Segment<'a> {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &str {
+        self.as_str()
     }
 }
 
@@ -48,21 +121,21 @@ mod tests {
     #[test]
     fn test_segments() {
         let mut segments = Segments::from("/foo/bar.txt");
-        assert_eq!(segments.as_str(), "foo/bar.txt");
-        assert_eq!(segments.next(), Some("foo"));
-        assert_eq!(segments.as_str(), "bar.txt");
-        assert_eq!(segments.next(), Some("bar.txt"));
-        assert_eq!(segments.as_str(), "");
-        assert_eq!(segments.next(), None);
-        assert_eq!(segments.as_str(), "");
-        assert_eq!(segments.next(), None);
+        assert_eq!(segments.remaining_path(), "foo/bar.txt");
+        assert_eq!(segments.next().map(|s| s.as_str()), Some("foo"));
+        assert_eq!(segments.remaining_path(), "bar.txt");
+        assert_eq!(segments.next().map(|s| s.as_str()), Some("bar.txt"));
+        assert_eq!(segments.remaining_path(), "");
+        assert_eq!(segments.next().map(|s| s.as_str()), None);
+        assert_eq!(segments.remaining_path(), "");
+        assert_eq!(segments.next().map(|s| s.as_str()), None);
     }
 
     #[test]
     fn test_root() {
         let mut segments = Segments::from("/");
-        assert_eq!(segments.as_str(), "");
-        assert_eq!(segments.next(), None);
+        assert_eq!(segments.remaining_path(), "");
+        assert_eq!(segments.next().map(|s| s.as_str()), None);
     }
 }
 
@@ -71,7 +144,7 @@ mod tests {
 pub struct EndpointContext<'a> {
     request: &'a Request,
     cookies: &'a Cookies,
-    segments: Option<Segments<'a>>,
+    segments: Segments<'a>,
 }
 
 impl<'a> EndpointContext<'a> {
@@ -79,7 +152,7 @@ impl<'a> EndpointContext<'a> {
         EndpointContext {
             request,
             cookies,
-            segments: Some(Segments::from(request.path())),
+            segments: Segments::from(request.path()),
         }
     }
 
@@ -93,13 +166,8 @@ impl<'a> EndpointContext<'a> {
         self.cookies
     }
 
-    /// Pop and return the front element of path segments.
-    pub fn next_segment(&mut self) -> Option<&str> {
-        self.segments.as_mut().and_then(|r| r.next())
-    }
-
-    /// Collect and return the remaining path segments, if available
-    pub fn take_segments(&mut self) -> Option<Segments<'a>> {
-        self.segments.take()
+    /// Returns the reference of remaining path segments
+    pub fn segments(&mut self) -> &mut Segments<'a> {
+        &mut self.segments
     }
 }

--- a/src/endpoint/method.rs
+++ b/src/endpoint/method.rs
@@ -12,14 +12,11 @@ impl<E: Endpoint> Endpoint for MatchMethod<E> {
     type Task = E::Task;
 
     fn apply(&self, ctx: &mut EndpointContext) -> Option<Self::Task> {
-        let f = try_opt!(self.1.apply(ctx));
-        if ctx.segments().count() > 0 {
-            return None;
+        if *ctx.request().method() == self.0 {
+            self.1.apply(ctx)
+        } else {
+            None
         }
-        if *ctx.request().method() != self.0 {
-            return None;
-        }
-        Some(f)
     }
 }
 

--- a/src/endpoint/method.rs
+++ b/src/endpoint/method.rs
@@ -13,7 +13,7 @@ impl<E: Endpoint> Endpoint for MatchMethod<E> {
 
     fn apply(&self, ctx: &mut EndpointContext) -> Option<Self::Task> {
         let f = try_opt!(self.1.apply(ctx));
-        if ctx.take_segments().map_or(0, |s| s.count()) > 0 {
+        if ctx.segments().count() > 0 {
             return None;
         }
         if *ctx.request().method() != self.0 {

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -31,7 +31,7 @@ pub use self::endpoint::{Endpoint, IntoEndpoint};
 pub use self::header::{header, header_opt};
 #[doc(inline)]
 pub use self::method::MatchMethod;
-pub use self::path::{path, paths};
+pub use self::path::{match_, path, paths};
 pub use self::result::{err, ok, result, EndpointErr, EndpointOk, EndpointResult};
 
 pub use self::and_then::AndThen;

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -26,7 +26,7 @@ pub(crate) mod with;
 
 // re-exports
 pub use self::body::body;
-pub use self::context::{EndpointContext, Segments};
+pub use self::context::{EndpointContext, Segment, Segments};
 pub use self::endpoint::{Endpoint, IntoEndpoint};
 pub use self::header::{header, header_opt};
 #[doc(inline)]


### PR DESCRIPTION
1. Add support for multiple segments (like `"foo/bar"`) and a wildcard (`"*"`) in `MatchPath`
2. `Or` checks the number of (consumed) segments if both endpoints are matched