### PR TITLE
docs(example): Fix wrong example name

### DIFF
--- a/doc/guide/src/quickstart.md
+++ b/doc/guide/src/quickstart.md
@@ -24,7 +24,7 @@ For example, you will run the simple example as follows:
 ```shell-session
 $ git clone https://github.com/finchers-rs/finchers.git
 $ cd finchers
-$ cargo run -p todo
+$ cargo run -p example-todo
 ```
 
 More examples are located in the directory [`examples/`][examples].


### PR DESCRIPTION
Example name has been written as todo, though it is set as example-todo in cargo file.
Please look on.

Thanks.