### PR TITLE
tweaks the trait bounds of Or

### DIFF
--- a/finchers-core/src/endpoint.rs
+++ b/finchers-core/src/endpoint.rs
@@ -33,7 +33,7 @@ use futures_core::future::TryFuture;
 
 use crate::either::Either;
 use crate::error::Error;
-use crate::generic::{Combine, Func, One, Tuple};
+use crate::generic::{Combine, Func, Tuple};
 use crate::input::{Cursor, Input};
 use crate::output::Responder;
 
@@ -200,12 +200,12 @@ pub trait EndpointExt: EndpointBase + Sized {
     /// from either `self` or `e` matched "better" to the input.
     fn or<E>(self, other: E) -> Or<Self, E::Endpoint>
     where
-        E: IntoEndpoint,
+        E: IntoEndpoint<Ok = Self::Ok>,
     {
         (Or {
             e1: self,
             e2: other.into_endpoint(),
-        }).ok::<One<Either<Self::Ok, E::Ok>>>()
+        }).ok::<Self::Ok>()
         .err::<Either<Self::Error, E::Error>>()
     }
 

--- a/finchers-core/src/generic.rs
+++ b/finchers-core/src/generic.rs
@@ -19,3 +19,51 @@ pub fn one<T>(x: T) -> One<T> {
 pub fn map_one<T, U>(x: One<T>, f: impl FnOnce(T) -> U) -> One<U> {
     one(f(x.0))
 }
+
+use crate::either::Either;
+use std::fmt;
+use std::marker::PhantomData;
+
+#[derive(Copy, Clone)]
+pub struct MapLeft<R>(PhantomData<fn() -> R>);
+
+impl<R> fmt::Debug for MapLeft<R> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("MapLeft").finish()
+    }
+}
+
+impl<L: Tuple, R: Tuple> Func<L> for MapLeft<R> {
+    type Out = (Either<L, R>,);
+
+    #[inline(always)]
+    fn call(self, args: L) -> Self::Out {
+        (Either::Left(args),)
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct MapRight<L>(PhantomData<fn() -> L>);
+
+impl<L> fmt::Debug for MapRight<L> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("MapRight").finish()
+    }
+}
+
+impl<L: Tuple, R: Tuple> Func<R> for MapRight<L> {
+    type Out = (Either<L, R>,);
+
+    #[inline(always)]
+    fn call(self, args: R) -> Self::Out {
+        (Either::Right(args),)
+    }
+}
+
+pub fn map_left<R>() -> MapLeft<R> {
+    MapLeft(PhantomData)
+}
+
+pub fn map_right<L>() -> MapRight<L> {
+    MapRight(PhantomData)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,17 +29,22 @@
 //! ```ignore
 //! #![feature(rust_2018_preview)]
 //!
+//! extern crate finchers;
+//! extern crate futures_util;
+//!
 //! use finchers::Endpoint;
+//! use futures_util::future::ready;
 //!
 //! fn build_endpoint() -> impl Endpoint {
 //!     use finchers::endpoint::prelude::*;
-//!     use finchers::choice;
+//!     use finchers::macros::routes;
 //!
-//!     path("api/v1").right(choice![
+//!     path("api/v1").and(routes![
 //!         get(param())
-//!             .map_ok(|id: u64| format!("GET: id={}", id)),
+//!             .and_then(|id: u64| ready(Ok((format!("GET: id={}", id),)))),
+//!
 //!         post(body())
-//!             .map_ok(|data: String| format!("POST: body={}", data)),
+//!             .and_then(|data: String| ready(Ok((format!("POST: body={}", data),)))),
 //!     ])
 //! }
 //!
@@ -109,9 +114,12 @@ pub mod output {
     pub use finchers_core::output::{payloads, responders, Responder};
 }
 
+pub mod macros {
+    pub use finchers_core::routes;
+}
+
 pub mod runtime;
 
-pub use finchers_core::choice;
 pub use finchers_core::endpoint::{Endpoint, EndpointBase};
 pub use finchers_core::error::{HttpError, Never};
 pub use finchers_core::input::Input;

--- a/tests/endpoint/or.rs
+++ b/tests/endpoint/or.rs
@@ -1,4 +1,3 @@
-use finchers_core::either::Either;
 use finchers_core::endpoint::{ok, EndpointExt};
 use finchers_core::endpoints::path::path;
 use finchers_core::local;
@@ -9,15 +8,9 @@ fn test_or_1() {
     let e2 = path("bar").and(ok(("bar",)));
     let endpoint = e1.or(e2);
 
-    assert_eq!(
-        local::get("/foo").apply(&endpoint),
-        Some(Ok((Either::Left(("foo",)),))),
-    );
+    assert_eq!(local::get("/foo").apply(&endpoint), Some(Ok(("foo",))),);
 
-    assert_eq!(
-        local::get("/bar").apply(&endpoint),
-        Some(Ok((Either::Right(("bar",)),))),
-    );
+    assert_eq!(local::get("/bar").apply(&endpoint), Some(Ok(("bar",))),);
 }
 
 #[test]
@@ -26,13 +19,10 @@ fn test_or_choose_longer_segments() {
     let e2 = path("foo/bar").and(ok(("foobar",)));
     let endpoint = e1.or(e2);
 
-    assert_eq!(
-        local::get("/foo").apply(&endpoint),
-        Some(Ok((Either::Left(("foo",)),))),
-    );
+    assert_eq!(local::get("/foo").apply(&endpoint), Some(Ok(("foo",))),);
 
     assert_eq!(
         local::get("/foo/bar").apply(&endpoint),
-        Some(Ok((Either::Right(("foobar",)),))),
+        Some(Ok(("foobar",))),
     );
 }


### PR DESCRIPTION
* add a trait bound `E1::Ok == E2::Ok`
* add a helper macro `routes!()` used to absorb type differences between endpoints
  - remove the old helper macro `choice!()`