### PR TITLE
add lifetime parameter to the definition of `Endpoint`

### DIFF
--- a/src/endpoint/and.rs
+++ b/src/endpoint/and.rs
@@ -18,16 +18,16 @@ pub struct And<E1, E2> {
     pub(super) e2: E2,
 }
 
-impl<E1, E2> Endpoint for And<E1, E2>
+impl<'a, E1, E2> Endpoint<'a> for And<E1, E2>
 where
-    E1: Endpoint,
-    E2: Endpoint,
+    E1: Endpoint<'a>,
+    E2: Endpoint<'a>,
     E1::Output: Combine<E2::Output>,
 {
     type Output = <E1::Output as Combine<E2::Output>>::Out;
     type Future = AndFuture<IntoFuture<E1::Future>, IntoFuture<E2::Future>>;
 
-    fn apply(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
         let f1 = self.e1.apply(ecx)?;
         let f2 = self.e2.apply(ecx)?;
         Ok(AndFuture {

--- a/src/endpoint/fixed.rs
+++ b/src/endpoint/fixed.rs
@@ -14,14 +14,11 @@ pub struct Fixed<E> {
     pub(super) endpoint: E,
 }
 
-impl<E> Endpoint for Fixed<E>
-where
-    E: Endpoint,
-{
+impl<'a, E: Endpoint<'a>> Endpoint<'a> for Fixed<E> {
     type Output = E::Output;
     type Future = FixedFuture<E::Future>;
 
-    fn apply(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
         match self.endpoint.apply(ecx) {
             Ok(future) => Ok(FixedFuture { inner: Ok(future) }),
             Err(err) => {

--- a/src/endpoint/lazy.rs
+++ b/src/endpoint/lazy.rs
@@ -68,15 +68,15 @@ pub struct Lazy<F> {
     f: F,
 }
 
-impl<F, R> Endpoint for Lazy<F>
+impl<'a, F, R> Endpoint<'a> for Lazy<F>
 where
-    F: Fn(PinMut<'_, Input>) -> R,
-    R: TryFuture<Error = Error>,
+    F: Fn(PinMut<'_, Input>) -> R + 'a,
+    R: TryFuture<Error = Error> + 'a,
 {
     type Output = One<R::Ok>;
     type Future = MapOk<R, fn(R::Ok) -> Self::Output>;
 
-    fn apply(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
         Ok((self.f)(ecx.input()).map_ok(one as fn(_) -> _))
     }
 }

--- a/src/endpoint/or.rs
+++ b/src/endpoint/or.rs
@@ -20,15 +20,15 @@ pub struct Or<E1, E2> {
     pub(super) e2: E2,
 }
 
-impl<E1, E2> Endpoint for Or<E1, E2>
+impl<'a, E1, E2> Endpoint<'a> for Or<E1, E2>
 where
-    E1: Endpoint,
-    E2: Endpoint,
+    E1: Endpoint<'a>,
+    E2: Endpoint<'a>,
 {
     type Output = One<WrappedEither<E1::Output, E2::Output>>;
     type Future = OrFuture<E1::Future, E2::Future>;
 
-    fn apply(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
         match {
             let mut ecx = ecx.clone_reborrowed();
             self.e1

--- a/src/endpoint/reject.rs
+++ b/src/endpoint/reject.rs
@@ -36,15 +36,15 @@ impl<F: Clone, E> Clone for Reject<F, E> {
     }
 }
 
-impl<F, E> Endpoint for Reject<F, E>
+impl<'a, F, E> Endpoint<'a> for Reject<F, E>
 where
-    F: Fn(PinMut<'_, Input>) -> E,
-    E: Into<Error>,
+    F: Fn(PinMut<'_, Input>) -> E + 'a,
+    E: Into<Error> + 'a,
 {
     type Output = ();
     type Future = future::Ready<Result<Self::Output, Error>>;
 
-    fn apply<'c>(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
         while let Some(..) = ecx.next_segment() {}
         Ok(future::ready(Err((self.f)(ecx.input()).into())))
     }

--- a/src/endpoint/then.rs
+++ b/src/endpoint/then.rs
@@ -20,53 +20,52 @@ pub struct Then<E, F> {
     pub(super) f: F,
 }
 
-impl<E, F> Endpoint for Then<E, F>
+impl<'a, E, F> Endpoint<'a> for Then<E, F>
 where
-    E: Endpoint,
-    F: Func<E::Output> + Clone,
-    F::Out: Future,
+    E: Endpoint<'a>,
+    F: Func<E::Output> + 'a,
+    F::Out: Future + 'a,
 {
     type Output = One<<F::Out as Future>::Output>;
-    type Future = ThenFuture<E::Future, F::Out, F>;
+    type Future = ThenFuture<'a, E::Future, F::Out, F>;
 
-    fn apply(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
         let f1 = self.endpoint.apply(ecx)?;
-        let f = self.f.clone();
         Ok(ThenFuture {
-            try_chain: TryChain::new(f1, f),
+            try_chain: TryChain::new(f1, &self.f),
         })
     }
 }
 
 #[allow(missing_docs)]
 #[derive(Debug)]
-pub struct ThenFuture<F1, F2, F>
+pub struct ThenFuture<'a, F1, F2, F>
 where
     F1: TryFuture<Error = Error>,
     F2: Future,
-    F: Func<F1::Ok, Out = F2>,
+    F: Func<F1::Ok, Out = F2> + 'a,
     F1::Ok: Tuple,
 {
-    try_chain: TryChain<F1, Map<F2, fn(F2::Output) -> Result<F2::Output, Error>>, F>,
+    try_chain: TryChain<F1, Map<F2, fn(F2::Output) -> Result<F2::Output, Error>>, &'a F>,
 }
 
-impl<F1, F2, F> ThenFuture<F1, F2, F>
+impl<'a, F1, F2, F> ThenFuture<'a, F1, F2, F>
 where
     F1: TryFuture<Error = Error>,
     F2: Future,
-    F: Func<F1::Ok, Out = F2>,
+    F: Func<F1::Ok, Out = F2> + 'a,
     F1::Ok: Tuple,
 {
     unsafe_pinned!(
-        try_chain: TryChain<F1, Map<F2, fn(F2::Output) -> Result<F2::Output, Error>>, F>
+        try_chain: TryChain<F1, Map<F2, fn(F2::Output) -> Result<F2::Output, Error>>, &'a F>
     );
 }
 
-impl<F1, F2, F> Future for ThenFuture<F1, F2, F>
+impl<'a, F1, F2, F> Future for ThenFuture<'a, F1, F2, F>
 where
     F1: TryFuture<Error = Error>,
     F2: Future,
-    F: Func<F1::Ok, Out = F2>,
+    F: Func<F1::Ok, Out = F2> + 'a,
     F1::Ok: Tuple,
 {
     type Output = Result<One<F2::Output>, Error>;

--- a/src/endpoint/unit.rs
+++ b/src/endpoint/unit.rs
@@ -14,11 +14,11 @@ pub struct Unit {
     _priv: (),
 }
 
-impl Endpoint for Unit {
+impl<'a> Endpoint<'a> for Unit {
     type Output = ();
     type Future = future::Ready<Result<Self::Output, Error>>;
 
-    fn apply(&self, _: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, _: &mut Context<'_>) -> EndpointResult<Self::Future> {
         Ok(future::ready(Ok(())))
     }
 }

--- a/src/endpoint/value.rs
+++ b/src/endpoint/value.rs
@@ -44,7 +44,7 @@ pub struct Value<T> {
     x: T,
 }
 
-impl<T: Clone> Endpoint for Value<T> {
+impl<'a, T: Clone + 'a> Endpoint<'a> for Value<T> {
     type Output = One<T>;
     type Future = future::Ready<Result<Self::Output, Error>>;
 

--- a/src/endpoints/body.rs
+++ b/src/endpoints/body.rs
@@ -43,7 +43,7 @@ impl fmt::Debug for Raw {
     }
 }
 
-impl Endpoint for Raw {
+impl<'e> Endpoint<'e> for Raw {
     type Output = One<Payload>;
     type Future = RawFuture;
 
@@ -166,7 +166,7 @@ impl<T> fmt::Debug for Parse<T> {
     }
 }
 
-impl<T> Endpoint for Parse<T>
+impl<'e, T> Endpoint<'e> for Parse<T>
 where
     T: FromBody,
 {
@@ -226,9 +226,9 @@ pub struct Json<T> {
     _marker: PhantomData<fn() -> T>,
 }
 
-impl<T> Endpoint for Json<T>
+impl<'e, T> Endpoint<'e> for Json<T>
 where
-    T: DeserializeOwned,
+    T: DeserializeOwned + 'static,
 {
     type Output = (T,);
     type Future = JsonFuture<T>;
@@ -293,7 +293,7 @@ pub struct UrlEncoded<T> {
     _marker: PhantomData<fn() -> T>,
 }
 
-impl<T> Endpoint for UrlEncoded<T>
+impl<'e, T> Endpoint<'e> for UrlEncoded<T>
 where
     T: FromQuery,
 {

--- a/src/endpoints/cookie.rs
+++ b/src/endpoints/cookie.rs
@@ -97,7 +97,7 @@ impl Required {
     }
 }
 
-impl Endpoint for Required {
+impl<'a> Endpoint<'a> for Required {
     type Output = One<Cookie<'static>>;
     type Future = Ready<Result<Self::Output, Error>>;
 
@@ -165,7 +165,7 @@ impl Optional {
     }
 }
 
-impl Endpoint for Optional {
+impl<'a> Endpoint<'a> for Optional {
     type Output = One<Option<Cookie<'static>>>;
     type Future = Ready<Result<Self::Output, Error>>;
 

--- a/src/endpoints/fs.rs
+++ b/src/endpoints/fs.rs
@@ -25,7 +25,7 @@ pub struct File {
     path: PathBuf,
 }
 
-impl Endpoint for File {
+impl<'a> Endpoint<'a> for File {
     type Output = One<NamedFile>;
     type Future = FileFuture;
 
@@ -47,7 +47,7 @@ pub struct Dir {
     root: PathBuf,
 }
 
-impl Endpoint for Dir {
+impl<'a> Endpoint<'a> for Dir {
     type Output = One<NamedFile>;
     type Future = FileFuture;
 

--- a/src/endpoints/path.rs
+++ b/src/endpoints/path.rs
@@ -37,7 +37,7 @@ pub struct MatchPath {
     encoded: String,
 }
 
-impl Endpoint for MatchPath {
+impl<'a> Endpoint<'a> for MatchPath {
     type Output = ();
     type Future = future::Ready<Result<Self::Output, Error>>;
 
@@ -66,7 +66,7 @@ pub struct EndPath {
     _priv: (),
 }
 
-impl Endpoint for EndPath {
+impl<'a> Endpoint<'a> for EndPath {
     type Output = ();
     type Future = future::Ready<Result<Self::Output, Error>>;
 
@@ -124,7 +124,7 @@ impl<T> fmt::Debug for Param<T> {
     }
 }
 
-impl<T> Endpoint for Param<T>
+impl<'a, T> Endpoint<'a> for Param<T>
 where
     T: FromEncodedStr,
 {
@@ -206,7 +206,7 @@ impl<T> fmt::Debug for Remains<T> {
     }
 }
 
-impl<T> Endpoint for Remains<T>
+impl<'a, T> Endpoint<'a> for Remains<T>
 where
     T: FromEncodedStr,
 {

--- a/src/endpoints/query.rs
+++ b/src/endpoints/query.rs
@@ -68,7 +68,7 @@ impl<T> fmt::Debug for Parse<T> {
     }
 }
 
-impl<T> Endpoint for Parse<T>
+impl<'a, T> Endpoint<'a> for Parse<T>
 where
     T: FromQuery,
 {
@@ -116,7 +116,7 @@ pub struct Raw {
     _priv: (),
 }
 
-impl Endpoint for Raw {
+impl<'a> Endpoint<'a> for Raw {
     type Output = One<String>;
     type Future = RawFuture;
 

--- a/src/generic/func.rs
+++ b/src/generic/func.rs
@@ -3,18 +3,18 @@ use super::hlist::Tuple;
 pub trait Func<Args: Tuple> {
     type Out;
 
-    fn call(self, args: Args) -> Self::Out;
+    fn call(&self, args: Args) -> Self::Out;
 }
 
 impl<F, R> Func<()> for F
 where
-    F: FnOnce() -> R,
+    F: Fn() -> R,
 {
     type Out = R;
 
     #[inline]
-    fn call(self, _: ()) -> Self::Out {
-        self()
+    fn call(&self, _: ()) -> Self::Out {
+        (*self)()
     }
 }
 
@@ -22,13 +22,13 @@ macro_rules! generics {
     ($T:ident) => {
         impl<F, R, $T> Func<($T,)> for F
         where
-            F: FnOnce($T) -> R,
+            F: Fn($T) -> R,
         {
             type Out = R;
 
             #[inline]
-            fn call(self, args: ($T,)) -> Self::Out {
-                (self)(args.0)
+            fn call(&self, args: ($T,)) -> Self::Out {
+                (*self)(args.0)
             }
         }
     };
@@ -37,15 +37,15 @@ macro_rules! generics {
 
         impl<F, R, $H, $($T),*> Func<($H, $($T),*)> for F
         where
-            F: FnOnce($H, $($T),*) -> R,
+            F: Fn($H, $($T),*) -> R,
         {
             type Out = R;
 
             #[inline]
-            fn call(self, args: ($H, $($T),*)) -> Self::Out {
+            fn call(&self, args: ($H, $($T),*)) -> Self::Out {
                 #[allow(non_snake_case)]
                 let ($H, $($T),*) = args;
-                (self)($H, $($T),*)
+                (*self)($H, $($T),*)
             }
         }
     };

--- a/src/rt/local.rs
+++ b/src/rt/local.rs
@@ -136,14 +136,11 @@ impl LocalRequest {
     }
 
     /// Apply this dummy request to the associated endpoint and get its response.
-    pub fn apply<E>(self, endpoint: E) -> Result<E::Output, Error>
-    where
-        E: Endpoint,
-    {
+    pub fn apply<'e, E: Endpoint<'e>>(self, endpoint: &'e E) -> Result<E::Output, Error> {
         let LocalRequest { mut request } = self;
         let request = request.take().expect("The request has already applied");
 
-        let app = App::new(&endpoint);
+        let app = App::new(endpoint);
 
         let mut future = app.dispatch_request(request);
         let future = poll_fn(move |cx| {

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -67,13 +67,13 @@ pub type LaunchResult<T> = Result<T, failure::Error>;
 /// Start the server with given endpoint and default configuration.
 pub fn launch<E>(endpoint: E) -> LaunchResult<()>
 where
-    E: Endpoint + Send + Sync + 'static,
+    E: Endpoint<'static> + Send + Sync,
     E::Output: Responder,
-    E::Future: Send + 'static,
+    E::Future: Send,
 {
     let config = Config::from_env();
 
-    let endpoint: &'static _ = unsafe { &*(&endpoint as *const _) };
+    let endpoint: &'static E = unsafe { &*(&endpoint as *const _) };
     let new_service = App::new(endpoint);
 
     let server = Server::try_bind(&config.addr())?

--- a/tests/endpoint/boxed.rs
+++ b/tests/endpoint/boxed.rs
@@ -1,0 +1,19 @@
+use finchers::endpoint::EndpointExt;
+use finchers::route;
+use finchers::rt::local;
+
+#[test]
+fn test_boxed() {
+    let endpoint = route!(@get /"foo");
+    let endpoint = endpoint.boxed::<()>();
+
+    assert_matches!(local::get("/foo").apply(&endpoint), Ok(()));
+}
+
+#[test]
+fn test_boxed_local() {
+    let endpoint = route!(@get /"foo");
+    let endpoint = endpoint.boxed_local::<()>();
+
+    assert_matches!(local::get("/foo").apply(&endpoint), Ok(..));
+}

--- a/tests/endpoint/mod.rs
+++ b/tests/endpoint/mod.rs
@@ -1,5 +1,7 @@
 mod and;
+mod boxed;
+mod or;
+
 // mod as_ok;
 // mod map;
-mod or;
 // mod then;


### PR DESCRIPTION
In the modified definition of `Endpoint`, the lifetime of the apply()'s receiver is added to the trait bound of the associated type `Future`.  It allows `Self::Future` to have some references to the inner fields in `Self`, that is, it is possible to delete unnecessary cloning at calling `apply()`.

### Notes
In the future, such treatments should be written using generic associated types as follows:

```rust
trait Endpoint {
    type Out;
    type Fut<'a>: TryFuture + 'a;

    fn apply<'a>(&'a self) -> Result<Self::Fut<'a>, Error>;
}
```