### PR TITLE
reform query APIs

### DIFF
--- a/examples/diesel/src/api.rs
+++ b/examples/diesel/src/api.rs
@@ -2,8 +2,6 @@ use diesel::prelude::*;
 use failure::Fallible;
 use serde::Deserialize;
 
-use finchers::input::query::{FromQuery, QueryItems, Serde};
-
 use crate::database::Connection;
 use crate::model::{NewPost, Post};
 use crate::schema::posts;
@@ -16,14 +14,6 @@ pub struct Query {
 impl Default for Query {
     fn default() -> Query {
         Query { count: 20 }
-    }
-}
-
-impl FromQuery for Query {
-    type Error = <Serde<Query> as FromQuery>::Error;
-
-    fn from_query(items: QueryItems) -> Result<Self, Self::Error> {
-        FromQuery::from_query(items).map(Serde::into_inner)
     }
 }
 

--- a/src/input/encoded.rs
+++ b/src/input/encoded.rs
@@ -30,6 +30,12 @@ impl PartialEq<str> for EncodedStr {
     }
 }
 
+impl<'a, 'b> PartialEq<&'b EncodedStr> for &'a EncodedStr {
+    fn eq(&self, other: &&'b EncodedStr) -> bool {
+        self.0 == *other.as_bytes()
+    }
+}
+
 impl<'a> PartialEq<str> for &'a EncodedStr {
     fn eq(&self, other: &str) -> bool {
         (*self).eq(other)

--- a/tests/endpoints/mod.rs
+++ b/tests/endpoints/mod.rs
@@ -1,2 +1,3 @@
 mod body;
 mod path;
+mod query;

--- a/tests/endpoints/query.rs
+++ b/tests/endpoints/query.rs
@@ -1,0 +1,55 @@
+use finchers::endpoint::EndpointExt;
+use finchers::endpoints::query;
+use finchers::input::query::Serde;
+use finchers::local;
+
+use serde::Deserialize;
+
+#[test]
+fn test_query_raw() {
+    let endpoint = query::raw().output::<(Option<String>,)>();
+
+    assert_matches!(
+        local::get("/?foo=bar")
+            .apply(&endpoint),
+        Ok((Some(ref s),)) if s == "foo=bar"
+    );
+
+    assert_matches!(local::get("/").apply(&endpoint), Ok((None,)));
+}
+
+#[test]
+fn test_query_required() {
+    #[derive(Debug, Deserialize)]
+    struct Query {
+        param: String,
+        count: Option<u32>,
+    }
+
+    let endpoint = query::required::<Serde<Query>>();
+
+    assert_matches!(
+        local::get("/?count=20&param=rustlang")
+            .apply(&endpoint),
+        Ok((ref query,)) if query.param == "rustlang" && query.count == Some(20)
+    );
+}
+
+#[test]
+fn test_query_optional() {
+    #[derive(Debug, Deserialize)]
+    struct Query {
+        param: String,
+        count: Option<u32>,
+    }
+
+    let endpoint = query::optional::<Serde<Query>>();
+
+    assert_matches!(
+        local::get("/?count=20&param=rustlang")
+            .apply(&endpoint),
+        Ok((Some(ref query),)) if query.param == "rustlang" && query.count == Some(20)
+    );
+
+    assert_matches!(local::get("/").apply(&endpoint), Ok((None,)));
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -6,6 +6,7 @@ extern crate failure;
 extern crate finchers;
 extern crate futures_util;
 extern crate http;
+extern crate serde;
 
 macro_rules! assert_matches {
     ($e:expr, $($t:tt)+) => {


### PR DESCRIPTION
* rename `query::parse()` to `query::required()`
* add `query::optional()`
* change the return type of `query::raw()` to `Option<String>`