### PR TITLE
add a new endpoint `AndThenWith`

### DIFF
--- a/src/endpoint/and_then_with.rs
+++ b/src/endpoint/and_then_with.rs
@@ -1,0 +1,79 @@
+use std::pin::PinMut;
+
+use futures_core::future::{Future, TryFuture};
+use futures_core::task;
+use futures_core::task::Poll;
+use futures_util::try_future;
+use futures_util::try_future::TryFutureExt;
+use pin_utils::unsafe_pinned;
+
+use super::try_chain::{TryChain, TryChainAction};
+use crate::endpoint::{Context, Endpoint, EndpointResult};
+use crate::error::Error;
+
+#[allow(missing_docs)]
+#[derive(Debug, Copy, Clone)]
+pub struct AndThenWith<E, T, F> {
+    pub(super) endpoint: E,
+    pub(super) ctx: T,
+    pub(super) f: F,
+}
+
+impl<'a, E, T, F, R> Endpoint<'a> for AndThenWith<E, T, F>
+where
+    E: Endpoint<'a>,
+    T: 'a,
+    F: Fn(&'a T, E::Output) -> R + 'a,
+    R: TryFuture<Error = Error> + 'a,
+{
+    type Output = (R::Ok,);
+    type Future = AndThenWithFuture<'a, E::Future, T, F, R>;
+
+    fn apply(&'a self, cx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+        let future = self.endpoint.apply(cx)?;
+        Ok(AndThenWithFuture {
+            try_chain: TryChain::new(future, (&self.ctx, &self.f)),
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct AndThenWithFuture<'a, Fut, T, F, R>
+where
+    Fut: TryFuture<Error = Error> + 'a,
+    T: 'a,
+    F: Fn(&'a T, Fut::Ok) -> R + 'a,
+    R: TryFuture<Error = Error> + 'a,
+{
+    #[cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
+    try_chain: TryChain<Fut, try_future::MapOk<R, fn(R::Ok) -> (R::Ok,)>, (&'a T, &'a F)>,
+}
+
+impl<'a, Fut, T, F, R> AndThenWithFuture<'a, Fut, T, F, R>
+where
+    Fut: TryFuture<Error = Error> + 'a,
+    T: 'a,
+    F: Fn(&'a T, Fut::Ok) -> R + 'a,
+    R: TryFuture<Error = Error> + 'a,
+{
+    unsafe_pinned!(
+        try_chain: TryChain<Fut, try_future::MapOk<R, fn(R::Ok) -> (R::Ok,)>, (&'a T, &'a F)>
+    );
+}
+
+impl<'a, Fut, T, F, R> Future for AndThenWithFuture<'a, Fut, T, F, R>
+where
+    Fut: TryFuture<Error = Error> + 'a,
+    T: 'a,
+    F: Fn(&'a T, Fut::Ok) -> R + 'a,
+    R: TryFuture<Error = Error> + 'a,
+{
+    type Output = Result<(R::Ok,), Error>;
+
+    fn poll(mut self: PinMut<'_, Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        self.try_chain().poll(cx, |result, (ctx, f)| match result {
+            Ok(out) => TryChainAction::Future(f(ctx, out).map_ok(|ok| (ok,))),
+            Err(err) => TryChainAction::Output(Err(err)),
+        })
+    }
+}

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod error;
 
 mod and;
 mod and_then;
+mod and_then_with;
 mod boxed;
 mod fixed;
 mod lazy;
@@ -23,6 +24,7 @@ pub use self::error::{EndpointError, EndpointResult};
 
 pub use self::and::And;
 pub use self::and_then::AndThen;
+pub use self::and_then_with::AndThenWith;
 pub use self::boxed::{Boxed, BoxedLocal};
 pub use self::fixed::Fixed;
 pub use self::map::Map;
@@ -164,13 +166,32 @@ pub trait EndpointExt<'a>: Endpoint<'a> + Sized {
         (Then { endpoint: self, f }).output::<(<F::Out as Future>::Output,)>()
     }
 
-    #[allow(missing_docs)]
-    fn and_then<F>(self, f: F) -> AndThen<Self, F>
+    /// Creates an endpoint which returns the new Future using the output of this endpoint.
+    fn and_then<F, R>(self, f: F) -> AndThen<Self, F>
     where
-        F: Func<Self::Output> + 'a,
-        F::Out: TryFuture<Error = Error>,
+        F: Func<Self::Output, Out = R> + 'a,
+        R: TryFuture<Error = Error>,
     {
-        (AndThen { endpoint: self, f }).output::<(<F::Out as TryFuture>::Ok,)>()
+        (AndThen { endpoint: self, f }).output::<(R::Ok,)>()
+    }
+
+    /// Creates an endpoint which returns the new Future using the output
+    /// of this endpoint and the specified value.
+    ///
+    /// The role of this combinator is very similar to `and_then()`.
+    /// The difference is that the closure used by this combinator takes a value
+    /// *by reference* whose lifetime is equal to the endpoint.
+    fn and_then_with<T, F, R>(self, ctx: T, f: F) -> AndThenWith<Self, T, F>
+    where
+        T: 'a,
+        F: Fn(&'a T, Self::Output) -> R + 'a,
+        R: TryFuture<Error = Error> + 'a,
+    {
+        (AndThenWith {
+            endpoint: self,
+            ctx,
+            f,
+        }).output::<(R::Ok,)>()
     }
 
     #[allow(missing_docs)]

--- a/tests/endpoint/and_then_with.rs
+++ b/tests/endpoint/and_then_with.rs
@@ -1,0 +1,23 @@
+use finchers::endpoint::{value, EndpointExt};
+use finchers::local;
+use futures_util::future::poll_fn;
+
+#[test]
+fn test_and_then_with() {
+    let prefix = String::from("Hello, ");
+    let endpoint =
+        value("Alice").and_then_with(prefix, |prefix: &String, (name,): (&'static str,)| {
+            poll_fn(move |_cx| {
+                // This closure captures a `String` by reference.
+                // Therefore, the Future returned by `poll_fn()` inherits the lifetime
+                // of `prefix`.
+                Ok(format!("{}{}.", prefix, name)).into()
+            })
+        });
+
+    assert_matches!(
+        local::get("/")
+            .apply(&endpoint),
+        Ok((ref s,)) if *s == "Hello, Alice."
+    )
+}

--- a/tests/endpoint/mod.rs
+++ b/tests/endpoint/mod.rs
@@ -1,5 +1,6 @@
 mod and;
 mod and_then;
+mod and_then_with;
 mod boxed;
 mod map;
 mod or;


### PR DESCRIPTION
The role of this endpoint is very similar to `AndThen`, but at the same time the Future returned by the provided closure is able to contain a *borrowing* of an arbitrary value without using `Arc` and so on.