### PR TITLE
tweak the definition of endpoints for parsing HTTP headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ futures-core-preview = { git = "https://github.com/rust-lang-nursery/futures-rs.
 futures-util-preview = { git = "https://github.com/rust-lang-nursery/futures-rs.git", branch = "master", features = ["tokio-compat"] }
 http = "0.1.10"
 hyper = "0.12.7"
+hyperx = "0.13.1"
 log = "0.4.3"
 mime = "0.3.8"
 mime_guess = "2.0.0-alpha.6"
@@ -55,6 +56,7 @@ serde_json = "1.0.24"
 serde_qs = "0.4.1"
 time = "0.1.40"
 tokio = "0.1.8"
+url = "1.7.1"
 
 [features]
 strict = []

--- a/src/input/header.rs
+++ b/src/input/header.rs
@@ -1,16 +1,82 @@
 //! Components for parsing header values.
 
+use std::fmt;
+
 use failure::Fail;
-use http::header::HeaderValue;
+use http::header::{HeaderValue, ToStrError};
+use hyperx::header::Header;
+use mime::Mime;
+use url::Url;
 
-/// Trait representing the conversion from an entry of HTTP header.
+use crate::error::Never;
+
+#[doc(hidden)]
+#[deprecated(
+    since = "0.12.0-alpha.3",
+    note = "This trait is going to remove before releasing 0.12.0."
+)]
 pub trait FromHeader: Sized {
-    /// The error type which will be returned from `from_header`.
     type Error: Fail;
-
-    /// The name of header associated with this type.
     const HEADER_NAME: &'static str;
-
-    /// Perform conversion from a byte sequence to a value of `Self`.
     fn from_header(value: &HeaderValue) -> Result<Self, Self::Error>;
+}
+
+/// Trait representing the conversion from a header value.
+pub trait FromHeaderValue: Sized + 'static {
+    /// The error type which will be returned from `from_header_value()`.
+    type Error: fmt::Debug + fmt::Display + Send + Sync + 'static;
+
+    /// Perform conversion from a header value to `Self`.
+    fn from_header_value(value: &HeaderValue) -> Result<Self, Self::Error>;
+}
+
+impl FromHeaderValue for HeaderValue {
+    type Error = Never;
+
+    fn from_header_value(value: &HeaderValue) -> Result<Self, Self::Error> {
+        Ok(value.clone())
+    }
+}
+
+impl FromHeaderValue for String {
+    type Error = ToStrError;
+
+    fn from_header_value(value: &HeaderValue) -> Result<Self, Self::Error> {
+        value.to_str().map(ToOwned::to_owned)
+    }
+}
+
+impl FromHeaderValue for Mime {
+    type Error = failure::Error;
+
+    fn from_header_value(value: &HeaderValue) -> Result<Self, Self::Error> {
+        Ok(value.to_str()?.parse()?)
+    }
+}
+
+impl FromHeaderValue for Url {
+    type Error = failure::Error;
+
+    fn from_header_value(value: &HeaderValue) -> Result<Self, Self::Error> {
+        Ok(Url::parse(value.to_str()?)?)
+    }
+}
+
+#[allow(missing_docs)]
+#[derive(Debug)]
+pub struct TypedHeader<T>(pub T);
+
+impl<T> TypedHeader<T> {
+    #[allow(missing_docs)]
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T: Header> FromHeaderValue for TypedHeader<T> {
+    type Error = hyperx::Error;
+
+    fn from_header_value(value: &HeaderValue) -> Result<Self, Self::Error> {
+        T::parse_header(&value.as_bytes().into()).map(TypedHeader)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ extern crate futures_core; // 0.3
 extern crate futures_util; // 0.3
 extern crate http;
 extern crate hyper;
+extern crate hyperx;
 extern crate log;
 extern crate mime;
 extern crate mime_guess;
@@ -75,6 +76,7 @@ extern crate serde_json;
 extern crate serde_qs;
 extern crate time;
 extern crate tokio;
+extern crate url;
 
 #[macro_use]
 mod macros;

--- a/tests/endpoints/header.rs
+++ b/tests/endpoints/header.rs
@@ -1,0 +1,95 @@
+use finchers::endpoint::{reject, EndpointExt};
+use finchers::endpoints::header;
+use finchers::error;
+use finchers::local;
+
+use http::header::CONTENT_TYPE;
+use matches::assert_matches;
+use mime::Mime;
+
+#[test]
+fn test_header_raw() {
+    let endpoint = header::raw(CONTENT_TYPE);
+
+    assert_matches!(
+        local::get("/")
+            .header("content-type", "application/json")
+            .apply(&endpoint),
+        Ok((Some(ref value),)) if value.as_bytes() == &b"application/json"[..]
+    );
+
+    assert_matches!(local::get("/").apply(&endpoint), Ok((None,)));
+}
+
+#[test]
+fn test_header_parse() {
+    let endpoint = header::parse::<Mime>("content-type");
+
+    assert_matches!(
+        local::get("/")
+            .header("content-type", "application/json")
+            .apply(&endpoint),
+        Ok((ref m,)) if *m == mime::APPLICATION_JSON
+    );
+
+    assert_matches!(
+        local::get("/").apply(&endpoint),
+        Err(ref e) if e.status_code().as_u16() == 404
+    );
+}
+
+#[test]
+fn test_header_parse_required() {
+    let endpoint = header::parse::<Mime>("content-type").required();
+
+    assert_matches!(
+        local::get("/")
+            .header("content-type", "application/json")
+            .apply(&endpoint),
+        Ok((ref m,)) if *m == mime::APPLICATION_JSON
+    );
+
+    assert_matches!(
+        local::get("/").apply(&endpoint),
+        Err(ref e) if e.status_code().as_u16() == 400
+    );
+}
+
+#[test]
+fn test_header_optional() {
+    let endpoint = header::optional::<Mime>("content-type");
+
+    assert_matches!(
+        local::get("/")
+            .header("content-type", "application/json")
+            .apply(&endpoint),
+        Ok((Some(ref m),)) if *m == mime::APPLICATION_JSON
+    );
+
+    assert_matches!(local::get("/").apply(&endpoint), Ok((None,)));
+}
+
+#[test]
+fn test_header_matches_with_rejection() {
+    let endpoint = header::matches("origin", "www.example.com").or(reject(|_| {
+        error::bad_request("The value of Origin is invalid")
+    }));
+
+    assert_matches!(
+        local::get("/")
+            .header("origin", "www.example.com")
+            .apply(&endpoint),
+        Ok(..)
+    );
+
+    // missing header
+    assert_matches!(local::get("/").apply(&endpoint), Err(..));
+
+    // invalid header value
+    assert_matches!(
+        local::get("/")
+            .header("origin", "www.rust-lang.org")
+            .apply(&endpoint),
+        Err(..)
+    );
+}

--- a/tests/endpoints/mod.rs
+++ b/tests/endpoints/mod.rs
@@ -1,3 +1,4 @@
 mod body;
+mod header;
 mod path;
 mod query;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -7,6 +7,7 @@ extern crate finchers;
 extern crate futures_util;
 extern crate http;
 extern crate matches;
+extern crate mime;
 extern crate serde;
 
 //mod codegen;


### PR DESCRIPTION
* add `header::raw()`
* make deprecated `FromHeader` and migrate to `FromHeaderValue`
  - the header name is set by endpoints
* rename `header::required()` to `header::parse()` and add additional mode
* rename `header::exact()` to `header::matches()`
* change the trait bound of `V` in `header::Matches<V>`