### PR TITLE
Re-implement EndpointError

### DIFF
--- a/src/endpoint/error.rs
+++ b/src/endpoint/error.rs
@@ -65,7 +65,7 @@ impl EndpointError {
     }
 
     #[doc(hidden)]
-    pub fn merge(self, other: EndpointError) -> EndpointError {
+    pub fn merge(&self, other: &EndpointError) -> EndpointError {
         use self::EndpointErrorKind::*;
         EndpointError(match (self.0, other.0) {
             (NotMatched, NotMatched) => NotMatched,
@@ -251,7 +251,7 @@ mod tests {
     fn test_merge_1() {
         let err1 = EndpointError::not_matched();
         let err2 = EndpointError::not_matched();
-        let err = err1.merge(err2);
+        let err = err1.merge(&err2);
         assert_matches!(err.0, EndpointErrorKind::NotMatched);
     }
 
@@ -260,7 +260,7 @@ mod tests {
         let err1 = EndpointError::not_matched();
         let err2 = EndpointError::method_not_allowed(AllowedMethods(AllowedMethodsMask::GET));
         assert_matches!(
-            err1.merge(err2).0,
+            err1.merge(&err2).0,
             EndpointErrorKind::MethodNotAllowed(allowed) if allowed.0 == AllowedMethodsMask::GET
         );
     }
@@ -270,7 +270,7 @@ mod tests {
         let err1 = EndpointError::method_not_allowed(AllowedMethods(AllowedMethodsMask::GET));
         let err2 = EndpointError::method_not_allowed(AllowedMethods(AllowedMethodsMask::POST));
         assert_matches!(
-            err1.merge(err2).0,
+            err1.merge(&err2).0,
             EndpointErrorKind::MethodNotAllowed(allowed) if allowed.0 == AllowedMethodsMask::GET | AllowedMethodsMask::POST
         );
     }

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -1,7 +1,7 @@
 //! Components for constructing `Endpoint`.
 
 mod context;
-pub(crate) mod error;
+pub mod error;
 
 mod and;
 mod and_then;

--- a/src/endpoint/or.rs
+++ b/src/endpoint/or.rs
@@ -60,7 +60,7 @@ where
             }
             Err(err1) => match self.e2.apply(ecx) {
                 Ok(future) => Ok(OrFuture::right(future)),
-                Err(err2) => Err(err1.merge(err2)),
+                Err(err2) => Err(err1.merge(&err2)),
             },
         }
     }

--- a/src/endpoint/or_strict.rs
+++ b/src/endpoint/or_strict.rs
@@ -37,7 +37,7 @@ where
             }
             Err(err1) => match self.e2.apply(ecx) {
                 Ok(future) => Ok(OrStrictFuture::right(future)),
-                Err(err2) => Err(err1.merge(err2)),
+                Err(err2) => Err(err1.merge(&err2)),
             },
         }
     }

--- a/src/endpoints/header.rs
+++ b/src/endpoints/header.rs
@@ -49,6 +49,7 @@ where
 {
     (Parse {
         name: HeaderName::from_static(name),
+        name_str: name,
         _marker: PhantomData,
     }).output::<(T,)>()
 }
@@ -56,6 +57,7 @@ where
 #[allow(missing_docs)]
 pub struct Parse<T> {
     name: HeaderName,
+    name_str: &'static str,
     _marker: PhantomData<fn() -> T>,
 }
 
@@ -76,7 +78,7 @@ where
         if cx.input().headers().contains_key(&self.name) {
             Ok(ParseFuture { endpoint: self })
         } else {
-            Err(EndpointError::not_matched())
+            Err(EndpointError::missing_header(self.name_str))
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,9 @@ extern crate time;
 extern crate tokio;
 extern crate url;
 
+#[cfg(test)]
+extern crate matches;
+
 #[macro_use]
 mod macros;
 mod app;

--- a/tests/endpoints/header.rs
+++ b/tests/endpoints/header.rs
@@ -34,7 +34,7 @@ fn test_header_parse() {
 
     assert_matches!(
         local::get("/").apply(&endpoint),
-        Err(ref e) if e.status_code().as_u16() == 404
+        Err(ref e) if e.status_code().as_u16() == 400
     );
 }
 

--- a/tests/endpoints/query.rs
+++ b/tests/endpoints/query.rs
@@ -1,3 +1,4 @@
+use finchers::endpoint::EndpointError;
 use finchers::endpoint::EndpointExt;
 use finchers::endpoints::query;
 use finchers::input::query::Serde;
@@ -20,7 +21,7 @@ fn test_query_raw() {
 }
 
 #[test]
-fn test_query_required() {
+fn test_query_parse() {
     #[derive(Debug, Deserialize)]
     struct Query {
         param: String,
@@ -33,6 +34,12 @@ fn test_query_required() {
         local::get("/?count=20&param=rustlang")
             .apply(&endpoint),
         Ok((ref query,)) if query.param == "rustlang" && query.count == Some(20)
+    );
+
+    assert_matches!(
+        local::get("/")
+            .apply(&endpoint),
+        Err(ref err) if err.is::<EndpointError>() && err.status_code().as_u16() == 400
     );
 }
 


### PR DESCRIPTION
Compatibility notes inside of built-in endpoints:

* `header::parse()` now returns `EndpointError::missing_header(name)` from `Endpoint::apply()` if the specified header is missing. The kind of this error has the status code "400 Bad Request".
* `query::required()` now returns `EndpointError::missing_query()` from `Endpoint::apply()` if the query string is empty.