### PR TITLE
Tweak core endpoints

### DIFF
--- a/src/endpoint/apply_fn.rs
+++ b/src/endpoint/apply_fn.rs
@@ -1,0 +1,36 @@
+use futures_core::future::TryFuture;
+
+use crate::common::Tuple;
+use crate::endpoint::{Context, Endpoint, EndpointResult};
+use crate::error::Error;
+
+/// Create an endpoint from a function.
+pub fn apply_fn<F, R>(f: F) -> ApplyFn<F>
+where
+    F: Fn(&mut Context<'_>) -> EndpointResult<R>,
+    R: TryFuture<Error = Error>,
+    R::Ok: Tuple,
+{
+    ApplyFn { f }
+}
+
+#[allow(missing_docs)]
+#[derive(Debug)]
+pub struct ApplyFn<F> {
+    f: F,
+}
+
+impl<'a, F, R> Endpoint<'a> for ApplyFn<F>
+where
+    F: Fn(&mut Context<'_>) -> EndpointResult<R> + 'a,
+    R: TryFuture<Error = Error> + 'a,
+    R::Ok: Tuple,
+{
+    type Output = R::Ok;
+    type Future = R;
+
+    #[inline]
+    fn apply(&'a self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+        (self.f)(ecx)
+    }
+}

--- a/src/endpoint/before_apply.rs
+++ b/src/endpoint/before_apply.rs
@@ -1,0 +1,23 @@
+use crate::endpoint::{Context, Endpoint, EndpointResult};
+
+#[allow(missing_docs)]
+#[derive(Debug, Copy, Clone)]
+pub struct BeforeApply<E, F> {
+    pub(super) endpoint: E,
+    pub(super) f: F,
+}
+
+impl<'a, E, F> Endpoint<'a> for BeforeApply<E, F>
+where
+    E: Endpoint<'a>,
+    F: Fn(&mut Context<'_>) -> EndpointResult<()> + 'a,
+{
+    type Output = E::Output;
+    type Future = E::Future;
+
+    #[inline]
+    fn apply(&'a self, cx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+        (self.f)(cx)?;
+        self.endpoint.apply(cx)
+    }
+}

--- a/src/endpoint/lazy.rs
+++ b/src/endpoint/lazy.rs
@@ -1,3 +1,7 @@
+#![allow(deprecated)]
+#![doc(hidden)]
+#![deprecated(since = "0.12.0-alpha.4", note = "use `lazy2()` instead.")]
+
 use std::pin::PinMut;
 
 use futures_core::future::TryFuture;
@@ -7,54 +11,6 @@ use crate::endpoint::{Context, Endpoint, EndpointResult};
 use crate::error::Error;
 use crate::input::Input;
 
-/// Create an endpoint which executes the provided closure for each request.
-///
-/// # Examples
-///
-/// ```
-/// # #![feature(futures_api)]
-/// #
-/// # extern crate finchers;
-/// # extern crate futures_core;
-/// # extern crate futures_util;
-/// # extern crate failure;
-/// # use finchers::endpoint::{lazy, EndpointExt};
-/// # use finchers::route;
-/// # use futures_core::future::Future;
-/// # use futures_util::future::ready;
-/// # use futures_util::try_future::TryFutureExt;
-/// use failure::Fallible;
-///
-/// # struct Conn { _p: (), }
-/// #
-/// #[derive(Default)]
-/// struct ConnPool {
-///     // ...
-/// #   _p: (),
-/// }
-///
-/// impl ConnPool {
-///     fn get_conn(&self) -> impl Future<Output = Fallible<Conn>> {
-///         // ...
-/// #       ready(Ok(Conn { _p: () }))
-///     }
-/// }
-///
-/// let pool = ConnPool::default();
-/// let acquire_conn = lazy(move |_| {
-///     pool.get_conn()
-///         .map_err(Into::into)
-/// });
-///
-/// let endpoint = route!(@get / "posts" / u32 /)
-///     .and(acquire_conn)
-///     .and_then(|id: u32, conn: Conn| {
-///         // ...
-/// #       drop(id);
-/// #       ready(Ok(conn))
-///     });
-/// # drop(endpoint);
-/// ```
 pub fn lazy<F, R>(f: F) -> Lazy<F>
 where
     F: Fn(PinMut<'_, Input>) -> R,
@@ -63,7 +19,6 @@ where
     Lazy { f }
 }
 
-#[allow(missing_docs)]
 #[derive(Debug, Copy, Clone)]
 pub struct Lazy<F> {
     f: F,

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -5,6 +5,7 @@ pub mod error;
 
 mod and;
 mod and_then;
+mod apply_fn;
 mod boxed;
 mod fixed;
 mod lazy;
@@ -36,6 +37,9 @@ pub use self::or_strict::OrStrict;
 pub use self::recover::Recover;
 pub use self::then::Then;
 
+pub use self::apply_fn::{apply_fn, ApplyFn};
+#[allow(deprecated)]
+#[doc(hidden)]
 pub use self::lazy::{lazy, Lazy};
 #[allow(deprecated)]
 #[doc(hidden)]

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -6,6 +6,7 @@ pub mod error;
 mod and;
 mod and_then;
 mod apply_fn;
+mod before_apply;
 mod boxed;
 mod fixed;
 mod lazy;
@@ -26,6 +27,7 @@ pub use self::error::{EndpointError, EndpointResult};
 
 pub use self::and::And;
 pub use self::and_then::AndThen;
+pub use self::before_apply::BeforeApply;
 pub use self::boxed::{Boxed, BoxedLocal};
 #[allow(deprecated)]
 #[doc(hidden)]
@@ -128,6 +130,14 @@ pub trait EndpointExt<'a>: Endpoint<'a> + Sized {
         Self: Endpoint<'a, Output = T>,
     {
         self
+    }
+
+    #[allow(missing_docs)]
+    fn before_apply<F>(self, f: F) -> BeforeApply<Self, F>
+    where
+        F: Fn(&mut Context<'_>) -> EndpointResult<()> + 'a,
+    {
+        (BeforeApply { endpoint: self, f }).output::<Self::Output>()
     }
 
     /// Create an endpoint which evaluates `self` and `e` and returns a pair of their tasks.

--- a/src/endpoint/unit.rs
+++ b/src/endpoint/unit.rs
@@ -1,4 +1,8 @@
-use futures_util::future;
+use std::pin::PinMut;
+
+use futures_core::future::Future;
+use futures_core::task;
+use futures_core::task::Poll;
 
 use crate::endpoint::{Context, Endpoint, EndpointResult};
 use crate::error::Error;
@@ -16,9 +20,24 @@ pub struct Unit {
 
 impl<'a> Endpoint<'a> for Unit {
     type Output = ();
-    type Future = future::Ready<Result<Self::Output, Error>>;
+    type Future = UnitFuture;
 
+    #[inline]
     fn apply(&'a self, _: &mut Context<'_>) -> EndpointResult<Self::Future> {
-        Ok(future::ready(Ok(())))
+        Ok(UnitFuture { _priv: () })
+    }
+}
+
+#[derive(Debug)]
+pub struct UnitFuture {
+    _priv: (),
+}
+
+impl Future for UnitFuture {
+    type Output = Result<(), Error>;
+
+    #[inline]
+    fn poll(self: PinMut<'_, Self>, _: &mut task::Context<'_>) -> Poll<Self::Output> {
+        Poll::Ready(Ok(()))
     }
 }


### PR DESCRIPTION
* Optimize the implementation of `Value<T>` and `Unit` (ffdc1af, 5e0b391)
* Add `ApplyFn` (af57833) and `BeforeApply` (9641aef)
* Make `Lazy` deprecated (af57833)