### PR TITLE
Switch to the new syntax API

### DIFF
--- a/examples/diesel/src/main.rs
+++ b/examples/diesel/src/main.rs
@@ -23,7 +23,7 @@ use std::env;
 use finchers::endpoint::{unit, EndpointExt};
 use finchers::endpoints::{body, query};
 use finchers::input::query::Serde;
-use finchers::{output, route, routes};
+use finchers::{output, path, routes};
 
 use crate::database::ConnectionPool;
 
@@ -36,8 +36,8 @@ fn main() -> Fallible<()> {
         async move { await!(fut).map_err(Into::into) }
     });
 
-    let endpoint = route!(/"api"/"v1"/"posts").and(routes!{
-        route!(@get /)
+    let endpoint = path!(/"api"/"v1"/"posts").and(routes!{
+        path!(@get /)
             .and(query::optional().map(|query: Option<_>| {
                 query.map(Serde::into_inner)
             }))
@@ -45,14 +45,14 @@ fn main() -> Fallible<()> {
             .and_then(async move |query, conn| await!(crate::api::get_posts(query, conn)).map_err(Into::into))
             .map(output::Json),
 
-        route!(@post /)
+        path!(@post /)
             .and(body::json())
             .and(acquire_conn.clone())
             .and_then(async move |new_post, conn| await!(crate::api::create_post(new_post, conn)).map_err(Into::into))
             .map(output::Json)
             .map(output::status::Created),
 
-        route!(@get / i32 /)
+        path!(@get / i32 /)
             .and(acquire_conn.clone())
             .and_then(async move |id, conn| {
                 await!(crate::api::find_post(id, conn))?

--- a/examples/staticfiles/src/main.rs
+++ b/examples/staticfiles/src/main.rs
@@ -2,15 +2,16 @@
 
 extern crate finchers;
 
+use finchers::endpoint::syntax::verb;
 use finchers::endpoint::EndpointExt;
 use finchers::endpoints::fs;
-use finchers::{route, routes};
+use finchers::{path, routes};
 
 fn main() {
     let endpoint = routes![
-        route!(@get /).and(fs::file("./Cargo.toml")),
-        route!(@get / "public").and(fs::dir("./static")),
-        route!(@get).map(|| "Not found"),
+        path!(@get /).and(fs::file("./Cargo.toml")),
+        path!(@get / "public").and(fs::dir("./static")),
+        verb::get().map(|| "Not found"),
     ];
 
     finchers::launch(endpoint).start("127.0.0.1:5000")

--- a/examples/template-tera/src/main.rs
+++ b/examples/template-tera/src/main.rs
@@ -1,10 +1,12 @@
 #![feature(async_await, futures_api)]
 
-use failure::SyncFailure;
+use finchers::endpoint::syntax::verb;
 use finchers::endpoint::{value, EndpointExt};
 use finchers::error::{fail, Error};
 use finchers::output::payload::Once;
-use finchers::{route, routes};
+use finchers::{path, routes};
+
+use failure::SyncFailure;
 use http::Response;
 use std::sync::Arc;
 use tera::{compile_templates, Context, Tera};
@@ -15,15 +17,15 @@ fn main() {
         "/templates/**/*"
     ))));
 
-    let index = route!(@get /)
+    let index = path!(@get /)
         .and(tera.clone())
         .map(|tera| render_template(tera, "index.html"));
 
-    let detail = route!(@get /"detail"/)
+    let detail = path!(@get /"detail"/)
         .and(tera.clone())
         .map(|tera| render_template(tera, "detail.html"));
 
-    let p404 = route!(@get)
+    let p404 = verb::get()
         .and(tera.clone())
         .map(|tera| render_template(tera, "404.html"));
 

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -2,7 +2,7 @@
 
 use finchers::endpoint::{unit, EndpointExt};
 use finchers::endpoints::body;
-use finchers::{output, route, routes};
+use finchers::{output, path, routes};
 
 use crate::db::ConnPool;
 
@@ -11,37 +11,37 @@ fn main() {
     let pool = ConnPool::default();
     let conn = unit().map(move || pool.conn());
 
-    let find_todo = route!(@get / u64 /)
+    let find_todo = path!(@get / u64 /)
         .and(conn.clone())
         .and_then(async move |id, conn| {
             await!(crate::api::find_todo(id, conn))?.ok_or_else(crate::util::not_found)
         }).map(output::Json);
 
-    let list_todos = route!(@get /)
+    let list_todos = path!(@get /)
         .and(conn.clone())
         .and_then(async move |conn| Ok(await!(crate::api::list_todos(conn))?))
         .map(output::Json);
 
-    let add_todo = route!(@post /)
+    let add_todo = path!(@post /)
         .and(body::json())
         .and(conn.clone())
         .and_then(async move |new_todo, conn| Ok(await!(crate::api::create_todo(new_todo, conn))?))
         .map(output::Json);
 
-    let patch_todo = route!(@patch / u64 /)
+    let patch_todo = path!(@patch / u64 /)
         .and(body::json())
         .and(conn.clone())
         .and_then(async move |id, patch, conn| {
             await!(crate::api::patch_todo(id, patch, conn))?.ok_or_else(crate::util::not_found)
         }).map(output::Json);
 
-    let delete_todo = route!(@delete / u64 /)
+    let delete_todo = path!(@delete / u64 /)
         .and(conn.clone())
         .and_then(async move |id, conn| {
             await!(crate::api::delete_todo(id, conn))?.ok_or_else(crate::util::not_found)
         });
 
-    let endpoint = route!(/ "api" / "v1" / "todos").and(routes![
+    let endpoint = path!(/ "api" / "v1" / "todos").and(routes![
         find_todo,
         list_todos,
         add_todo,

--- a/src/endpoint/error.rs
+++ b/src/endpoint/error.rs
@@ -1,11 +1,24 @@
 //! Definition of `EndpointError` and supplemental components.
 
-use bitflags::bitflags;
-use http::{Method, StatusCode};
+use http::StatusCode;
 use std::fmt;
-use std::ops::{BitOr, BitOrAssign};
 
+use crate::endpoint::syntax::verb::Verbs;
 use crate::error::HttpError;
+
+#[doc(hidden)]
+#[deprecated(
+    since = "0.12.0-alpha.4",
+    note = "renamed to `endpoint::syntax::verb::Verbs`."
+)]
+pub use crate::endpoint::syntax::verb::Verbs as AllowedMethods;
+
+#[doc(hidden)]
+#[deprecated(
+    since = "0.12.0-alpha.4",
+    note = "renamed to `endpoint::syntax::verb::VerbsIter`."
+)]
+pub use crate::endpoint::syntax::verb::VerbsIter as AllowedMethodsIter;
 
 /// A type alias of `Result<T, E>` with the error type fixed at `EndpointError`.
 pub type EndpointResult<T> = Result<T, EndpointError>;
@@ -20,7 +33,7 @@ pub struct EndpointError(EndpointErrorKind);
 #[derive(Debug, Copy, Clone)]
 enum EndpointErrorKind {
     NotMatched,
-    MethodNotAllowed(AllowedMethods),
+    MethodNotAllowed(Verbs),
     InvalidRequest(InvalidRequest),
 }
 
@@ -48,7 +61,7 @@ impl EndpointError {
 
     /// Create a value of `EndpointError` whth an annotation that
     /// the current endpoint does not matche to the provided HTTP method.
-    pub fn method_not_allowed(allowed: AllowedMethods) -> EndpointError {
+    pub fn method_not_allowed(allowed: Verbs) -> EndpointError {
         EndpointError(EndpointErrorKind::MethodNotAllowed(allowed))
     }
 
@@ -73,7 +86,7 @@ impl EndpointError {
             (NotMatched, InvalidRequest(reason)) => InvalidRequest(reason),
             (MethodNotAllowed(allowed), NotMatched) => MethodNotAllowed(allowed),
             (MethodNotAllowed(allowed1), MethodNotAllowed(allowed2)) => {
-                MethodNotAllowed(AllowedMethods(allowed1.0 | allowed2.0))
+                MethodNotAllowed(allowed1 | allowed2)
             }
             (MethodNotAllowed(..), InvalidRequest(reason)) => InvalidRequest(reason),
             (InvalidRequest(reason), ..) => InvalidRequest(reason),
@@ -112,140 +125,11 @@ impl HttpError for EndpointError {
     }
 }
 
-bitflags! {
-    pub(crate) struct AllowedMethodsMask: u32 {
-        const GET         = 0b_0000_0000_0001;
-        const POST        = 0b_0000_0000_0010;
-        const PUT         = 0b_0000_0000_0100;
-        const DELETE      = 0b_0000_0000_1000;
-        const HEAD        = 0b_0000_0001_0000;
-        const OPTIONS     = 0b_0000_0010_0000;
-        const CONNECT     = 0b_0000_0100_0000;
-        const PATCH       = 0b_0000_1000_0000;
-        const TRACE       = 0b_0001_0000_0000;
-    }
-}
-
-/// A collection type which represents a set of allowed HTTP methods.
-#[derive(Debug, Clone, Copy)]
-pub struct AllowedMethods(pub(crate) AllowedMethodsMask);
-
-macro_rules! define_allowed_methods_constructors {
-    ($($METHOD:ident,)*) => {$(
-        #[allow(missing_docs)]
-        pub const $METHOD: AllowedMethods = AllowedMethods(AllowedMethodsMask::$METHOD);
-    )*};
-}
-
-impl AllowedMethods {
-    define_allowed_methods_constructors![
-        GET, POST, PUT, DELETE, HEAD, OPTIONS, CONNECT, PATCH, TRACE,
-    ];
-
-    #[allow(missing_docs)]
-    pub fn from_http(allowed: &Method) -> Option<AllowedMethods> {
-        macro_rules! pat {
-            ($($METHOD:ident),*) => {
-                match allowed {
-                    $(
-                        ref m if *m == Method::$METHOD => Some(AllowedMethods(AllowedMethodsMask::$METHOD)),
-                    )*
-                    _ => None,
-                }
-            }
-        }
-        pat!(GET, POST, PUT, DELETE, HEAD, OPTIONS, CONNECT, PATCH, TRACE)
-    }
-}
-
-impl BitOr for AllowedMethods {
-    type Output = AllowedMethods;
-
-    #[inline]
-    fn bitor(self, other: AllowedMethods) -> Self::Output {
-        AllowedMethods(self.0 | other.0)
-    }
-}
-
-impl BitOrAssign for AllowedMethods {
-    #[inline]
-    fn bitor_assign(&mut self, other: AllowedMethods) {
-        self.0 |= other.0;
-    }
-}
-
-impl IntoIterator for AllowedMethods {
-    type Item = &'static Method;
-    type IntoIter = AllowedMethodsIter;
-
-    fn into_iter(self) -> Self::IntoIter {
-        AllowedMethodsIter {
-            allowed: self.0,
-            cursor: AllowedMethodsMask::GET,
-        }
-    }
-}
-
-#[allow(missing_docs)]
-#[derive(Debug)]
-pub struct AllowedMethodsIter {
-    allowed: AllowedMethodsMask,
-    cursor: AllowedMethodsMask,
-}
-
-impl Iterator for AllowedMethodsIter {
-    type Item = &'static Method;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        macro_rules! dump_method {
-            ($m:expr => [$($METHOD:ident),*]) => {$(
-                if $m.contains(AllowedMethodsMask::$METHOD) { return Some(&Method::$METHOD) }
-            )*}
-        }
-        loop {
-            let masked = self.allowed & self.cursor;
-            self.cursor = AllowedMethodsMask::from_bits_truncate(self.cursor.bits() << 1);
-            if self.cursor.is_empty() {
-                return None;
-            }
-            dump_method!(masked => [
-                GET,
-                POST,
-                PUT,
-                DELETE,
-                HEAD,
-                OPTIONS,
-                CONNECT,
-                PATCH,
-                TRACE
-            ]);
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use http::Method;
     use matches::assert_matches;
-
-    #[test]
-    fn test_methods_single_get() {
-        let methods: Vec<Method> = AllowedMethods(AllowedMethodsMask::GET)
-            .into_iter()
-            .cloned()
-            .collect();
-        assert_eq!(methods, vec![Method::GET]);
-    }
-
-    #[test]
-    fn test_methods_two_methods() {
-        let methods: Vec<Method> =
-            AllowedMethods(AllowedMethodsMask::GET | AllowedMethodsMask::POST)
-                .into_iter()
-                .cloned()
-                .collect();
-        assert_eq!(methods, vec![Method::GET, Method::POST]);
-    }
 
     #[test]
     fn test_merge_1() {
@@ -258,20 +142,20 @@ mod tests {
     #[test]
     fn test_merge_2() {
         let err1 = EndpointError::not_matched();
-        let err2 = EndpointError::method_not_allowed(AllowedMethods(AllowedMethodsMask::GET));
+        let err2 = EndpointError::method_not_allowed(Verbs::GET);
         assert_matches!(
             err1.merge(&err2).0,
-            EndpointErrorKind::MethodNotAllowed(allowed) if allowed.0 == AllowedMethodsMask::GET
+            EndpointErrorKind::MethodNotAllowed(allowed) if allowed.contains(&Method::GET)
         );
     }
 
     #[test]
     fn test_merge_3() {
-        let err1 = EndpointError::method_not_allowed(AllowedMethods(AllowedMethodsMask::GET));
-        let err2 = EndpointError::method_not_allowed(AllowedMethods(AllowedMethodsMask::POST));
+        let err1 = EndpointError::method_not_allowed(Verbs::GET);
+        let err2 = EndpointError::method_not_allowed(Verbs::POST);
         assert_matches!(
             err1.merge(&err2).0,
-            EndpointErrorKind::MethodNotAllowed(allowed) if allowed.0 == AllowedMethodsMask::GET | AllowedMethodsMask::POST
+            EndpointErrorKind::MethodNotAllowed(allowed) if allowed.contains(&Method::GET) && allowed.contains(&Method::POST)
         );
     }
 }

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -2,6 +2,7 @@
 
 mod context;
 pub mod error;
+pub mod syntax;
 
 mod and;
 mod and_then;

--- a/src/endpoint/or.rs
+++ b/src/endpoint/or.rs
@@ -123,23 +123,25 @@ where
 /// # Example
 ///
 /// ```
-/// # use finchers::{route, routes};
+/// # use finchers::{path, routes};
 /// # use finchers::endpoint::EndpointExt;
 /// # use finchers::endpoints::body;
 /// #
-/// let get_post = route!(@get / i32 /)
+/// let get_post = path!(@get / i32 /)
 ///     .map(|id| format!("get_post: {}", id));
 ///
-/// let add_post = route!(@post /).and(body::text())
+/// let add_post = path!(@post /)
+///     .and(body::text())
 ///     .map(|data: String| format!("add_post: {}", data));
 ///
 /// // ...
 ///
-/// let endpoint = route!(/ "posts").and(routes![
-///     get_post,
-///     add_post,
-///     // ...
-/// ]);
+/// let endpoint = path!(/ "posts")
+///     .and(routes![
+///         get_post,
+///         add_post,
+///         // ...
+///     ]);
 /// # drop(endpoint);
 /// ```
 #[macro_export]

--- a/src/endpoint/or.rs
+++ b/src/endpoint/or.rs
@@ -60,7 +60,7 @@ where
             }
             Err(err1) => match self.e2.apply(ecx) {
                 Ok(future) => Ok(OrFuture::right(future)),
-                Err(err2) => Err(err1.merge(&err2)),
+                Err(err2) => Err(err1.merge(err2)),
             },
         }
     }

--- a/src/endpoint/or_strict.rs
+++ b/src/endpoint/or_strict.rs
@@ -37,7 +37,7 @@ where
             }
             Err(err1) => match self.e2.apply(ecx) {
                 Ok(future) => Ok(OrStrictFuture::right(future)),
-                Err(err2) => Err(err1.merge(&err2)),
+                Err(err2) => Err(err1.merge(err2)),
             },
         }
     }

--- a/src/endpoint/syntax/mod.rs
+++ b/src/endpoint/syntax/mod.rs
@@ -193,7 +193,8 @@ where
 
     fn apply(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
         let s = ecx.next_segment().ok_or_else(EndpointError::not_matched)?;
-        let x = T::from_encoded_str(s).map_err(|_err| EndpointError::not_matched())?;
+        let x =
+            T::from_encoded_str(s).map_err(|err| EndpointError::custom(failure::err_msg(err)))?;
         Ok(Extracted(Some(x)))
     }
 }
@@ -241,8 +242,8 @@ where
     type Future = Extracted<T>;
 
     fn apply(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
-        let result =
-            T::from_encoded_str(ecx.remaining_path()).map_err(|_err| EndpointError::not_matched());
+        let result = T::from_encoded_str(ecx.remaining_path())
+            .map_err(|err| EndpointError::custom(failure::err_msg(err)));
         while let Some(..) = ecx.next_segment() {}
         result.map(|x| Extracted(Some(x)))
     }

--- a/src/endpoint/syntax/mod.rs
+++ b/src/endpoint/syntax/mod.rs
@@ -1,0 +1,249 @@
+//! Components for building endpoints which matches to a specific HTTP path.
+
+#[allow(missing_docs)]
+pub mod verb;
+
+use std::borrow::Cow;
+use std::fmt;
+use std::marker::PhantomData;
+use std::pin::PinMut;
+
+use futures_core::future::Future;
+use futures_core::task;
+use futures_core::task::Poll;
+
+use percent_encoding::{define_encode_set, percent_encode, DEFAULT_ENCODE_SET};
+
+use crate::endpoint::{Context, Endpoint, EndpointError, EndpointResult, IntoEndpoint};
+use crate::error::Error;
+use crate::input::FromEncodedStr;
+
+#[doc(hidden)]
+#[derive(Debug)]
+#[must_use = "futures does not anything unless polled."]
+pub struct Matched {
+    _priv: (),
+}
+
+impl Future for Matched {
+    type Output = Result<(), Error>;
+
+    #[inline]
+    fn poll(self: PinMut<'_, Self>, _: &mut task::Context<'_>) -> Poll<Self::Output> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[doc(hidden)]
+#[derive(Debug)]
+#[must_use = "futures does not anything unless polled."]
+pub struct Extracted<T>(Option<T>);
+
+impl<T> Future for Extracted<T> {
+    type Output = Result<(T,), Error>;
+
+    #[inline]
+    fn poll(self: PinMut<'_, Self>, _: &mut task::Context<'_>) -> Poll<Self::Output> {
+        let x = unsafe { PinMut::get_mut_unchecked(self) }
+            .0
+            .take()
+            .expect("This future has already polled");
+        Poll::Ready(Ok((x,)))
+    }
+}
+
+// ==== MatchSegment =====
+
+define_encode_set! {
+    /// The encode set for MatchSegment
+    #[doc(hidden)]
+    pub SEGMENT_ENCODE_SET = [DEFAULT_ENCODE_SET] | {'/'}
+}
+
+/// Create an endpoint which validates a path segment.
+///
+/// It takes a path segment from the context and check if it is equal
+/// to the specified value.
+pub fn segment(s: impl AsRef<str>) -> MatchSegment {
+    let s = s.as_ref();
+    debug_assert!(!s.is_empty());
+    (MatchSegment {
+        encoded: percent_encode(s.as_bytes(), SEGMENT_ENCODE_SET).to_string(),
+    }).with_output::<()>()
+}
+
+#[allow(missing_docs)]
+#[derive(Debug, Clone)]
+pub struct MatchSegment {
+    encoded: String,
+}
+
+impl<'a> Endpoint<'a> for MatchSegment {
+    type Output = ();
+    type Future = Matched;
+
+    fn apply(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+        let s = ecx.next_segment().ok_or_else(EndpointError::not_matched)?;
+        if s == self.encoded {
+            Ok(Matched { _priv: () })
+        } else {
+            Err(EndpointError::not_matched())
+        }
+    }
+}
+
+impl<'a, 's> IntoEndpoint<'a> for &'s str {
+    type Output = ();
+    type Endpoint = MatchSegment;
+
+    #[inline(always)]
+    fn into_endpoint(self) -> Self::Endpoint {
+        segment(self)
+    }
+}
+
+impl<'a> IntoEndpoint<'a> for String {
+    type Output = ();
+    type Endpoint = MatchSegment;
+
+    #[inline(always)]
+    fn into_endpoint(self) -> Self::Endpoint {
+        segment(self)
+    }
+}
+
+impl<'a, 's> IntoEndpoint<'a> for Cow<'s, str> {
+    type Output = ();
+    type Endpoint = MatchSegment;
+
+    #[inline(always)]
+    fn into_endpoint(self) -> Self::Endpoint {
+        segment(self)
+    }
+}
+
+// ==== MatchEos ====
+
+/// Create an endpoint which checks if the current context is reached the end of segments.
+#[inline]
+pub fn eos() -> MatchEos {
+    (MatchEos { _priv: () }).with_output::<()>()
+}
+
+#[allow(missing_docs)]
+#[derive(Debug, Copy, Clone)]
+pub struct MatchEos {
+    _priv: (),
+}
+
+impl<'a> Endpoint<'a> for MatchEos {
+    type Output = ();
+    type Future = Matched;
+
+    fn apply(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+        match ecx.next_segment() {
+            None => Ok(Matched { _priv: () }),
+            Some(..) => Err(EndpointError::not_matched()),
+        }
+    }
+}
+
+// ==== Param ====
+
+/// Create an endpoint which parses a path segment into the specified type.
+///
+/// This endpoint will skip the current request
+/// if the segments is empty or the conversion is failed.
+#[inline]
+pub fn param<T>() -> Param<T>
+where
+    T: FromEncodedStr,
+{
+    (Param {
+        _marker: PhantomData,
+    }).with_output::<(T,)>()
+}
+
+#[allow(missing_docs)]
+pub struct Param<T> {
+    _marker: PhantomData<fn() -> T>,
+}
+
+impl<T> Copy for Param<T> {}
+
+impl<T> Clone for Param<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> fmt::Debug for Param<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Param").finish()
+    }
+}
+
+impl<'a, T> Endpoint<'a> for Param<T>
+where
+    T: FromEncodedStr,
+{
+    type Output = (T,);
+    type Future = Extracted<T>;
+
+    fn apply(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+        let s = ecx.next_segment().ok_or_else(EndpointError::not_matched)?;
+        let x = T::from_encoded_str(s).map_err(|_err| EndpointError::not_matched())?;
+        Ok(Extracted(Some(x)))
+    }
+}
+
+// ==== Remains ====
+
+/// Create an endpoint which parses the remaining path segments into the specified type.
+///
+/// This endpoint will skip the current request if the conversion is failed.
+#[inline]
+pub fn remains<T>() -> Remains<T>
+where
+    T: FromEncodedStr,
+{
+    (Remains {
+        _marker: PhantomData,
+    }).with_output::<(T,)>()
+}
+
+#[allow(missing_docs)]
+pub struct Remains<T> {
+    _marker: PhantomData<fn() -> (T)>,
+}
+
+impl<T> Copy for Remains<T> {}
+
+impl<T> Clone for Remains<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> fmt::Debug for Remains<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Remains").finish()
+    }
+}
+
+impl<'a, T> Endpoint<'a> for Remains<T>
+where
+    T: FromEncodedStr,
+{
+    type Output = (T,);
+    type Future = Extracted<T>;
+
+    fn apply(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+        let result =
+            T::from_encoded_str(ecx.remaining_path()).map_err(|_err| EndpointError::not_matched());
+        while let Some(..) = ecx.next_segment() {}
+        result.map(|x| Extracted(Some(x)))
+    }
+}

--- a/src/endpoint/syntax/verb.rs
+++ b/src/endpoint/syntax/verb.rs
@@ -129,7 +129,7 @@ impl Verbs {
         Verbs(Methods::all())
     }
 
-    pub(crate) fn contains(&self, method: &Method) -> bool {
+    pub(crate) fn contains(self, method: &Method) -> bool {
         macro_rules! compare_methods {
             ($($METHOD:ident),*) => {
                 match method {

--- a/src/endpoint/syntax/verb.rs
+++ b/src/endpoint/syntax/verb.rs
@@ -1,0 +1,227 @@
+use std::ops::{BitOr, BitOrAssign};
+
+use bitflags::bitflags;
+use http::Method;
+
+use super::Matched;
+use crate::endpoint::{Context, Endpoint, EndpointError, EndpointResult};
+
+/// Create an endpoint which checks if the verb of current request
+/// is equal to the specified value.
+pub fn verbs(allowed: Verbs) -> MatchVerbs {
+    (MatchVerbs { allowed }).with_output::<()>()
+}
+
+#[allow(missing_docs)]
+#[derive(Debug, Copy, Clone)]
+pub struct MatchVerbs {
+    allowed: Verbs,
+}
+
+impl<'a> Endpoint<'a> for MatchVerbs {
+    type Output = ();
+    type Future = Matched;
+
+    fn apply(&'a self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+        if self.allowed.contains(ecx.input().method()) {
+            Ok(Matched { _priv: () })
+        } else {
+            Err(EndpointError::method_not_allowed(self.allowed))
+        }
+    }
+}
+
+macro_rules! define_verbs {
+    ($(
+        ($name:ident, $METHOD:ident, $Endpoint:ident),
+    )*) => {$(
+
+        #[allow(missing_docs)]
+        #[inline]
+        pub fn $name() -> $Endpoint {
+            $Endpoint {
+                _priv: (),
+            }
+        }
+
+        #[allow(missing_docs)]
+        #[derive(Debug, Copy, Clone)]
+        pub struct $Endpoint {
+            _priv: (),
+        }
+
+        impl<'e> Endpoint<'e> for $Endpoint {
+            type Output = ();
+            type Future = Matched;
+
+            #[inline]
+            fn apply(&'e self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+                if *ecx.input().method() == Method::$METHOD {
+                    Ok(Matched { _priv: () })
+                } else {
+                    Err(EndpointError::method_not_allowed(Verbs::$METHOD))
+                }
+            }
+        }
+    )*};
+}
+
+define_verbs! {
+    (get, GET, MatchVerbGet),
+    (post, POST, MatchVerbPost),
+    (put, PUT, MatchVerbPut),
+    (delete, DELETE, MatchVerbDelete),
+    (head, HEAD, MatchVerbHead),
+    (options, OPTIONS, MatchVerbOptions),
+    (connect, CONNECT, MatchVerbConnect),
+    (patch, PATCH, MatchVerbPatch),
+    (trace, TRACE, MatchVerbTrace),
+}
+
+/// A collection type which represents a set of allowed HTTP methods.
+#[derive(Debug, Clone, Copy)]
+pub struct Verbs(Methods);
+
+bitflags! {
+    struct Methods: u32 {
+        const GET         = 0b_0000_0000_0001;
+        const POST        = 0b_0000_0000_0010;
+        const PUT         = 0b_0000_0000_0100;
+        const DELETE      = 0b_0000_0000_1000;
+        const HEAD        = 0b_0000_0001_0000;
+        const OPTIONS     = 0b_0000_0010_0000;
+        const CONNECT     = 0b_0000_0100_0000;
+        const PATCH       = 0b_0000_1000_0000;
+        const TRACE       = 0b_0001_0000_0000;
+    }
+}
+
+macro_rules! define_allowed_methods_constructors {
+    ($($METHOD:ident,)*) => {$(
+        #[allow(missing_docs)]
+        pub const $METHOD: Verbs = Verbs(Methods::$METHOD);
+    )*};
+}
+
+impl Verbs {
+    define_allowed_methods_constructors![
+        GET, POST, PUT, DELETE, HEAD, OPTIONS, CONNECT, PATCH, TRACE,
+    ];
+
+    #[allow(missing_docs)]
+    pub fn single(method: &Method) -> Option<Verbs> {
+        macro_rules! pat {
+            ($($METHOD:ident),*) => {
+                match method {
+                    $(
+                        ref m if *m == Method::$METHOD => Some(Verbs::$METHOD),
+                    )*
+                    _ => None,
+                }
+            }
+        }
+        pat!(GET, POST, PUT, DELETE, HEAD, OPTIONS, CONNECT, PATCH, TRACE)
+    }
+
+    #[allow(missing_docs)]
+    #[inline]
+    pub fn any() -> Verbs {
+        Verbs(Methods::all())
+    }
+
+    pub(crate) fn contains(&self, method: &Method) -> bool {
+        macro_rules! compare_methods {
+            ($($METHOD:ident),*) => {
+                match method {
+                    $(
+                        m if *m == Method::$METHOD => self.0.contains(Methods::$METHOD),
+                    )*
+                    _ => false,
+                }
+            }
+        }
+        compare_methods![GET, POST, PUT, DELETE, HEAD, OPTIONS, CONNECT, PATCH, TRACE]
+    }
+}
+
+impl BitOr for Verbs {
+    type Output = Verbs;
+
+    #[inline]
+    fn bitor(self, other: Verbs) -> Self::Output {
+        Verbs(self.0 | other.0)
+    }
+}
+
+impl BitOrAssign for Verbs {
+    #[inline]
+    fn bitor_assign(&mut self, other: Verbs) {
+        self.0 |= other.0;
+    }
+}
+
+impl IntoIterator for Verbs {
+    type Item = &'static Method;
+    type IntoIter = VerbsIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        VerbsIter {
+            allowed: self.0,
+            cursor: Methods::GET,
+        }
+    }
+}
+
+#[allow(missing_docs)]
+#[derive(Debug)]
+pub struct VerbsIter {
+    allowed: Methods,
+    cursor: Methods,
+}
+
+impl Iterator for VerbsIter {
+    type Item = &'static Method;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        macro_rules! dump_method {
+            ($m:expr => [$($METHOD:ident),*]) => {$(
+                if $m.contains(Methods::$METHOD) { return Some(&Method::$METHOD) }
+            )*}
+        }
+        loop {
+            let masked = self.allowed & self.cursor;
+            self.cursor = Methods::from_bits_truncate(self.cursor.bits() << 1);
+            if self.cursor.is_empty() {
+                return None;
+            }
+            dump_method!(masked => [
+                GET,
+                POST,
+                PUT,
+                DELETE,
+                HEAD,
+                OPTIONS,
+                CONNECT,
+                PATCH,
+                TRACE
+            ]);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_methods_single_get() {
+        let methods: Vec<Method> = Verbs::GET.into_iter().cloned().collect();
+        assert_eq!(methods, vec![Method::GET]);
+    }
+
+    #[test]
+    fn test_methods_two_methods() {
+        let methods: Vec<Method> = (Verbs::GET | Verbs::POST).into_iter().cloned().collect();
+        assert_eq!(methods, vec![Method::GET, Method::POST]);
+    }
+}

--- a/src/endpoint/value.rs
+++ b/src/endpoint/value.rs
@@ -16,7 +16,7 @@ use crate::error::Error;
 /// # extern crate finchers;
 /// # extern crate futures_util;
 /// # use finchers::endpoint::{value, EndpointExt};
-/// # use finchers::route;
+/// # use finchers::path;
 /// # use futures_util::future::ready;
 /// #
 /// #[derive(Clone)]
@@ -30,7 +30,7 @@ use crate::error::Error;
 /// #   Conn { _p: () }
 /// };
 ///
-/// let endpoint = route!(@get / "posts" / u32 /)
+/// let endpoint = path!(@get / "posts" / u32 /)
 ///     .and(value(conn))
 ///     .and_then(|id: u32, conn: Conn| {
 ///         // ...

--- a/src/endpoints/cookie.rs
+++ b/src/endpoints/cookie.rs
@@ -54,9 +54,9 @@ impl Mode {
 /// ```
 /// # use finchers::endpoints::cookie;
 /// # use finchers::endpoint::{unit, EndpointExt};
-/// # use finchers::{route, routes};
+/// # use finchers::{path, routes};
 /// #
-/// let home = route!(@get / "home")
+/// let home = path!(@get / "home")
 ///     .and(routes![
 ///         cookie::required("session")
 ///             .map(|_| "authorized"),
@@ -122,9 +122,9 @@ impl<'a> Endpoint<'a> for Required {
 /// # use finchers::endpoints::cookie;
 /// # use finchers::endpoint::EndpointExt;
 /// # use finchers::input::cookie::Cookie;
-/// # use finchers::route;
+/// # use finchers::path;
 /// #
-/// let home = route!(@get / "home")
+/// let home = path!(@get / "home")
 ///     .and(cookie::optional("session"))
 ///     .map(|c: Option<Cookie>| {
 ///         // ...

--- a/src/endpoints/method.rs
+++ b/src/endpoints/method.rs
@@ -2,7 +2,7 @@
 
 use http::Method;
 
-use crate::endpoint::error::{AllowedMethods, AllowedMethodsMask};
+use crate::endpoint::syntax::verb::Verbs;
 use crate::endpoint::{Context, Endpoint, EndpointError, EndpointResult, IntoEndpoint};
 
 #[allow(missing_docs)]
@@ -10,7 +10,7 @@ use crate::endpoint::{Context, Endpoint, EndpointError, EndpointResult, IntoEndp
 pub struct MatchMethod<E> {
     endpoint: E,
     method: Method,
-    allowed: AllowedMethods,
+    allowed: Verbs,
 }
 
 impl<'a, E: Endpoint<'a>> Endpoint<'a> for MatchMethod<E> {
@@ -31,7 +31,7 @@ pub fn method<E>(method: Method, endpoint: E) -> MatchMethod<E>
 where
     for<'e> E: Endpoint<'e>,
 {
-    let allowed = AllowedMethods::from_http(&method).expect("unsupported HTTP method");
+    let allowed = Verbs::single(&method).expect("unsupported HTTP method");
     MatchMethod {
         endpoint,
         method,
@@ -69,7 +69,7 @@ macro_rules! define_method {
                 if *ecx.input().method() == Method::$method {
                     self.endpoint.apply(ecx)
                 } else {
-                    Err(EndpointError::method_not_allowed(AllowedMethods(AllowedMethodsMask::$method)))
+                    Err(EndpointError::method_not_allowed(Verbs::$method))
                 }
             }
         }

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -4,6 +4,17 @@ pub mod body;
 pub mod cookie;
 pub mod fs;
 pub mod header;
+#[doc(hidden)]
+#[deprecated(
+    since = "0.12.0-alpha.4",
+    note = "use components in `endpoint::syntax` instead"
+)]
 pub mod method;
+
+#[doc(hidden)]
+#[deprecated(
+    since = "0.12.0-alpha.4",
+    note = "use components in `endpoint::syntax` instead"
+)]
 pub mod path;
 pub mod query;

--- a/src/endpoints/path.rs
+++ b/src/endpoints/path.rs
@@ -20,8 +20,6 @@ define_encode_set! {
 
 // ==== MatchPath =====
 
-/// Create an endpoint which takes a path segment and check if it equals
-/// to the specified value.
 pub fn path(s: impl AsRef<str>) -> MatchPath {
     let s = s.as_ref();
     debug_assert!(!s.is_empty());
@@ -78,21 +76,6 @@ impl<'a> Endpoint<'a> for EndPath {
 
 // ==== Param ====
 
-/// Create an endpoint which extracts one segment from the path
-/// and converts it to the value of `T`.
-///
-/// If the segments is empty of the conversion to `T` is failed,
-/// this endpoint will skip the request.
-///
-/// # Example
-///
-/// ```
-/// # use finchers::endpoint::EndpointExt;
-/// # use finchers::endpoints::path::{path, param};
-/// let endpoint = path("posts").and(param())
-///     .map(|id: i32| (format!("id={}", id),));
-/// # drop(endpoint);
-/// ```
 #[inline]
 pub fn param<T>() -> Param<T>
 where
@@ -159,21 +142,6 @@ impl<E: Fail> HttpError for ParamError<E> {
 
 // ==== Remains ====
 
-/// Create an endpoint which extracts all remaining segments from
-/// the path and converts them to the value of `T`.
-///
-/// If the conversion to `T` is failed, this endpoint will skip the request.
-///
-/// # Example
-///
-/// ```
-/// # use finchers::endpoint::EndpointExt;
-/// # use finchers::endpoints::path::{path, remains};
-/// # use std::path::PathBuf;
-/// let endpoint = path("foo").and(remains())
-///     .map(|path: PathBuf| format!("path={}", path.display()));
-/// # drop(endpoint);
-/// ```
 #[inline]
 pub fn remains<T>() -> Remains<T>
 where

--- a/src/endpoints/query.rs
+++ b/src/endpoints/query.rs
@@ -1,5 +1,6 @@
 //! Endpoints for parsing query strings.
 
+use failure::format_err;
 use std::future::Future;
 use std::marker::PhantomData;
 use std::pin::PinMut;
@@ -84,7 +85,7 @@ where
                 _marker: PhantomData,
             })
         } else {
-            Err(EndpointError::missing_query())
+            Err(EndpointError::custom(format_err!("missing query")))
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,18 +20,18 @@
 //!
 //! ```
 //! use finchers::endpoint::EndpointExt;
-//! use finchers::endpoints::{body, path};
-//! use finchers::route;
+//! use finchers::endpoints::body;
+//! use finchers::path;
 //!
 //! fn main() {
-//!     let get_post = route!(@get / u64 /)
+//!     let get_post = path!(@get / u64 /)
 //!         .map(|id: u64| format!("GET: id={}", id));
 //!
-//!     let create_post = route!(@post /)
+//!     let create_post = path!(@post /)
 //!         .and(body::text())
 //!         .map(|data: String| format!("POST: body={}", data));
 //!
-//!     let post_api = path::path("posts")
+//!     let post_api = path!(/ "posts")
 //!         .and(get_post.or(create_post));
 //!
 //! # std::mem::drop(move || {

--- a/src/local.rs
+++ b/src/local.rs
@@ -8,10 +8,10 @@
 //! # use finchers::endpoints::body;
 //! # use finchers::endpoint::EndpointExt;
 //! # use finchers::local;
-//! # use finchers::route;
+//! # use finchers::path;
 //! #
 //! // impl Endpoint<Output = (u32, String)>
-//! let endpoint = route!(@post / u32 /)
+//! let endpoint = path!(@post / u32 /)
 //!     .and(body::text());
 //!
 //! const MSG: &str = "The quick brown fox jumps over the lazy dog";
@@ -32,9 +32,9 @@
 //! # use finchers::endpoints::body;
 //! # use finchers::endpoint::EndpointExt;
 //! # use finchers::local;
-//! # use finchers::route;
+//! # use finchers::path;
 //! #
-//! let endpoint = route!(@put / "posts" / u32 /)
+//! let endpoint = path!(@put / "posts" / u32 /)
 //!     .and(body::text())
 //!     .map(|id: u32, body: String| {
 //!         format!("update a post (id = {}): {}", id, body)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,75 +1,5 @@
-/// A helper macro for creating the instance of`Endpoint` from multiple routes.
-///
-/// # Example
-///
-/// ```
-/// # use finchers::{route, routes};
-/// # use finchers::endpoint::EndpointExt;
-/// # use finchers::endpoints::body;
-/// #
-/// let get_post = route!(@get / i32 /)
-///     .map(|id| format!("get_post: {}", id));
-///
-/// let add_post = route!(@post /).and(body::text())
-///     .map(|data: String| format!("add_post: {}", data));
-///
-/// // ...
-///
-/// let endpoint = route!(/ "posts").and(routes![
-///     get_post,
-///     add_post,
-///     // ...
-/// ]);
-/// # drop(endpoint);
-/// ```
-#[macro_export]
-macro_rules! routes {
-    () => { $crate::routes_impl!(@error); };
-    ($h:expr) => {  $crate::routes_impl!(@error); };
-    ($h:expr,) => {  $crate::routes_impl!(@error); };
-    ($e1:expr, $e2:expr) => { $crate::routes_impl!($e1, $e2); };
-    ($e1:expr, $e2:expr,) => { $crate::routes_impl!($e1, $e2); };
-    ($e1:expr, $e2:expr, $($t:expr),*) => { $crate::routes_impl!($e1, $e2, $($t),*); };
-    ($e1:expr, $e2:expr, $($t:expr,)+) => { $crate::routes_impl!($e1, $e2, $($t),+); };
-}
-
 #[doc(hidden)]
-#[macro_export]
-macro_rules! routes_impl {
-    ($e1:expr, $e2:expr, $($t:expr),*) => {{
-        $crate::routes_impl!($e1, $crate::routes_impl!($e2, $($t),*))
-    }};
-
-    ($e1:expr, $e2:expr) => {{
-        $crate::endpoint::EndpointExt::or(
-            $crate::endpoint::IntoEndpoint::into_endpoint($e1),
-            $crate::endpoint::IntoEndpoint::into_endpoint($e2),
-        )
-    }};
-
-    (@error) => { compile_error!("The `routes!()` macro requires at least two elements."); };
-}
-
-/// A helper macro for creating an endpoint from the specified segments.
-///
-/// # Example
-///
-/// The following macro call
-///
-/// ```ignore
-/// route!(@get / "api" / "v1" / "posts" / i32);
-/// ```
-///
-/// will be roughly expanded to:
-///
-/// ```ignore
-/// method::get(
-///     path("api")
-///         .and(path("v1"))
-///         .and(path("posts"))
-///         .and(param::<i32>())
-/// )
-/// ```
+#[deprecated(since = "0.12.0-alpha.4", note = "use `path!()` instead.")]
 #[macro_export]
 macro_rules! route {
     // with method
@@ -103,32 +33,4 @@ macro_rules! route_impl {
 
     (@segment $t:ty) => ( $crate::endpoints::path::param::<$t>() );
     (@segment $s:expr) => ( $crate::endpoints::path::path($s) );
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::endpoint::{Endpoint, EndpointExt};
-    use crate::endpoints::path::path;
-
-    #[test]
-    fn compile_test_route() {
-        let _ = route!().with_output::<()>();
-        let _ = route!(/).with_output::<()>();
-        let _ = route!(/"foo"/i32).with_output::<(i32,)>();
-
-        let _ = route!(@get /).with_output::<()>();
-        let _ = route!(@get / "foo" / String / "bar").with_output::<(String,)>();
-        let _ = route!(@get / "foo" / String / i32 / "bar" /).with_output::<(String, i32)>();
-        let _ = route!(@get / i32).with_output::<(i32,)>();
-        let _ = route!(@get / i32 / ).with_output::<(i32,)>();
-    }
-
-    #[test]
-    #[allow(unused_variables)]
-    fn compile_test_routes() {
-        let e1 = path("foo");
-        let e2 = routes!(e1, path("bar"), path("baz"));
-        let e3 = routes!(path("foobar"), e2);
-        let e4 = routes!(path("foobar"), e3,);
-    }
 }

--- a/tests/endpoint/boxed.rs
+++ b/tests/endpoint/boxed.rs
@@ -1,12 +1,12 @@
 use finchers::endpoint::Endpoint;
 use finchers::local;
-use finchers::route;
+use finchers::path;
 
 use matches::assert_matches;
 
 #[test]
 fn test_boxed() {
-    let endpoint = route!(@get /"foo");
+    let endpoint = path!(@get /"foo");
     let endpoint = endpoint.boxed::<()>();
 
     assert_matches!(local::get("/foo").apply(&endpoint), Ok(()));
@@ -14,7 +14,7 @@ fn test_boxed() {
 
 #[test]
 fn test_boxed_local() {
-    let endpoint = route!(@get /"foo");
+    let endpoint = path!(@get /"foo");
     let endpoint = endpoint.boxed_local::<()>();
 
     assert_matches!(local::get("/foo").apply(&endpoint), Ok(..));

--- a/tests/endpoint/macros.rs
+++ b/tests/endpoint/macros.rs
@@ -1,0 +1,28 @@
+use finchers::endpoint::syntax;
+use finchers::endpoint::Endpoint;
+use finchers::{path, routes};
+
+#[test]
+fn compile_test_path() {
+    let _ = path!(/).with_output::<()>();
+    let _ = path!(/ "foo" / i32).with_output::<(i32,)>();
+
+    let _ = path!(@get /).with_output::<()>();
+    let _ = path!(@get / "foo" / String / "bar").with_output::<(String,)>();
+    let _ = path!(@get / "foo" / String / i32 / "bar" /).with_output::<(String, i32)>();
+    let _ = path!(@get / i32).with_output::<(i32,)>();
+    let _ = path!(@get / i32 / ).with_output::<(i32,)>();
+
+    let _ = path!(@get / "posts" / i32 / "repo" / { syntax::remains::<String>() })
+        .with_output::<(i32, String)>();
+}
+
+#[test]
+fn compile_test_routes() {
+    use finchers::endpoint::syntax;
+
+    let e1 = syntax::segment("foo");
+    let e2 = routes!(e1, syntax::segment("bar"), syntax::segment("baz"));
+    let e3 = routes!(syntax::segment("foobar"), e2);
+    let _e4 = routes!(syntax::segment("foobar"), e3,);
+}

--- a/tests/endpoint/mod.rs
+++ b/tests/endpoint/mod.rs
@@ -1,8 +1,10 @@
 mod and;
 mod and_then;
 mod boxed;
+mod macros;
 mod map;
 mod or;
 mod or_strict;
 mod recover;
+mod syntax;
 mod then;

--- a/tests/endpoint/or.rs
+++ b/tests/endpoint/or.rs
@@ -1,14 +1,14 @@
 use failure::format_err;
+use finchers::endpoint::syntax;
 use finchers::endpoint::{value, EndpointExt};
-use finchers::endpoints::path::path;
 use finchers::error::bad_request;
 use finchers::local;
 use matches::assert_matches;
 
 #[test]
 fn test_or_1() {
-    let e1 = path("foo").and(value("foo"));
-    let e2 = path("bar").and(value("bar"));
+    let e1 = syntax::segment("foo").and(value("foo"));
+    let e2 = syntax::segment("bar").and(value("bar"));
     let endpoint = e1.or(e2);
 
     assert_matches!(local::get("/foo").apply(&endpoint), Ok(..));
@@ -18,8 +18,8 @@ fn test_or_1() {
 
 #[test]
 fn test_or_choose_longer_segments() {
-    let e1 = path("foo").and(value("foo"));
-    let e2 = path("foo").and(path("bar")).and(value("foobar"));
+    let e1 = syntax::segment("foo").and(value("foo"));
+    let e2 = syntax::segment("foo").and("bar").and(value("foobar"));
     let endpoint = e1.or(e2);
 
     assert_matches!(local::get("/foo").apply(&endpoint), Ok(..));
@@ -29,8 +29,8 @@ fn test_or_choose_longer_segments() {
 
 #[test]
 fn test_or_with_rejection() {
-    let endpoint = path("foo")
-        .or(path("bar"))
+    let endpoint = syntax::segment("foo")
+        .or(syntax::segment("bar"))
         .or_reject_with(|_err, _cx| bad_request(format_err!("custom rejection")));
 
     assert_matches!(local::get("/foo").apply(&endpoint), Ok(..));

--- a/tests/endpoint/or_strict.rs
+++ b/tests/endpoint/or_strict.rs
@@ -1,5 +1,6 @@
+use finchers::endpoint::syntax;
 use finchers::endpoint::EndpointExt;
-use finchers::endpoints::{body, method, query};
+use finchers::endpoints::{body, query};
 use finchers::input::query::{from_csv, Serde};
 use finchers::local;
 
@@ -16,8 +17,8 @@ struct Param {
 
 #[test]
 fn test_or_strict() {
-    let query = method::get(query::required::<Serde<Param>>());
-    let form = method::post(body::urlencoded::<Serde<Param>>());
+    let query = syntax::verb::get().and(query::required::<Serde<Param>>());
+    let form = syntax::verb::post().and(body::urlencoded::<Serde<Param>>());
     let endpoint = query.or_strict(form);
 
     let query_str = "query=rustlang&count=42&tags=tokio,hyper";

--- a/tests/endpoint/recover.rs
+++ b/tests/endpoint/recover.rs
@@ -9,6 +9,7 @@ fn test_recover() {
     let endpoint = syntax::verb::get()
         .and(syntax::segment("posts"))
         .and(syntax::param::<u32>())
+        .and(syntax::eos())
         .map(|id: u32| format!("param={}", id))
         .with_output::<(String,)>();
 
@@ -26,5 +27,5 @@ fn test_recover() {
     assert!(local::get("/posts/42").apply(&recovered).is_ok());
     assert!(local::get("/posts/").apply(&recovered).is_ok());
     assert!(local::post("/posts/42").apply(&recovered).is_ok());
-    assert!(local::get("/posts/foo").apply(&recovered).is_err());
+    assert!(local::get("/posts/foo").apply(&recovered).is_ok());
 }

--- a/tests/endpoint/recover.rs
+++ b/tests/endpoint/recover.rs
@@ -1,13 +1,16 @@
-use finchers::endpoint::{EndpointError, EndpointExt};
-use finchers::endpoints::{method, path};
+use finchers::endpoint::syntax;
+use finchers::endpoint::{Endpoint, EndpointError, EndpointExt};
 use finchers::local;
 use futures_util::future::ready;
 use http::Response;
 
 #[test]
 fn test_recover() {
-    let endpoint = method::get(path::path("posts").and(path::param::<u32>()))
-        .map(|id: u32| format!("param={}", id));
+    let endpoint = syntax::verb::get()
+        .and(syntax::segment("posts"))
+        .and(syntax::param::<u32>())
+        .map(|id: u32| format!("param={}", id))
+        .with_output::<(String,)>();
 
     let recovered = endpoint.or_reject().recover(|err| {
         if err.is::<EndpointError>() {

--- a/tests/endpoint/syntax.rs
+++ b/tests/endpoint/syntax.rs
@@ -1,5 +1,5 @@
 use finchers::endpoint::syntax;
-use finchers::endpoint::{Endpoint, EndpointExt};
+use finchers::endpoint::{Endpoint, EndpointError, EndpointExt};
 use finchers::local;
 use finchers::path;
 
@@ -48,7 +48,7 @@ fn test_extract_integer() {
     assert_matches!(local::get("/42").apply(&endpoint), Ok((42i32,)));
     assert_matches!(
         local::get("/foo").apply(&endpoint),
-        Err(ref e) if e.status_code() == StatusCode::BAD_REQUEST
+        Err(ref e) if e.is::<EndpointError>() && e.status_code() == StatusCode::BAD_REQUEST
     );
 }
 

--- a/tests/endpoint/syntax.rs
+++ b/tests/endpoint/syntax.rs
@@ -1,13 +1,14 @@
-use finchers::endpoint::EndpointExt;
-use finchers::endpoints::path::{param, path, remains};
+use finchers::endpoint::syntax;
+use finchers::endpoint::{Endpoint, EndpointExt};
 use finchers::local;
+use finchers::path;
 
 use http::StatusCode;
 use matches::assert_matches;
 
 #[test]
 fn test_match_single_segment() {
-    let endpoint = path("foo");
+    let endpoint = syntax::segment("foo");
     assert_matches!(local::get("/foo").apply(&endpoint), Ok(()));
     assert_matches!(
         local::get("/bar").apply(&endpoint),
@@ -17,7 +18,7 @@ fn test_match_single_segment() {
 
 #[test]
 fn test_match_multi_segments() {
-    let endpoint = path("foo").and(path("bar"));
+    let endpoint = syntax::segment("foo").and(syntax::segment("bar"));
     assert_matches!(local::get("/foo/bar").apply(&endpoint), Ok(()));
     assert_matches!(local::get("/foo/bar/").apply(&endpoint), Ok(()));
     assert_matches!(local::get("/foo/bar/baz").apply(&endpoint), Ok(()));
@@ -33,7 +34,7 @@ fn test_match_multi_segments() {
 
 #[test]
 fn test_match_encoded_path() {
-    let endpoint = path("foo/bar");
+    let endpoint = syntax::segment("foo/bar");
     assert_matches!(local::get("/foo%2Fbar").apply(&endpoint), Ok(()));
     assert_matches!(
         local::get("/foo/bar").apply(&endpoint),
@@ -43,7 +44,7 @@ fn test_match_encoded_path() {
 
 #[test]
 fn test_extract_integer() {
-    let endpoint = param::<i32>();
+    let endpoint = syntax::param::<i32>();
     assert_matches!(local::get("/42").apply(&endpoint), Ok((42i32,)));
     assert_matches!(
         local::get("/foo").apply(&endpoint),
@@ -53,9 +54,21 @@ fn test_extract_integer() {
 
 #[test]
 fn test_extract_strings() {
-    let endpoint = path("foo").and(remains::<String>());
+    let endpoint = syntax::segment("foo").and(syntax::remains::<String>());
     assert_matches!(
         local::get("/foo/bar/baz/").apply(&endpoint),
         Ok((ref s,)) if s == "bar/baz/"
+    );
+}
+
+#[test]
+fn test_path_macro() {
+    let endpoint = path!(@get / "posts" / u32 / "stars" /)
+        .map(|id: u32| format!("id={}", id))
+        .with_output::<(String,)>();
+    assert_matches!(
+        local::get("/posts/42/stars")
+            .apply(&endpoint),
+        Ok((ref s,)) if s == "id=42"
     );
 }

--- a/tests/endpoints/mod.rs
+++ b/tests/endpoints/mod.rs
@@ -1,4 +1,3 @@
 mod body;
 mod header;
-mod path;
 mod query;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -20,9 +20,9 @@ fn smoketest() {
     use finchers::local;
     use finchers::output::status::Created;
     use finchers::output::Json;
-    use finchers::route;
+    use finchers::path;
 
-    let endpoint = route!(@get / "api" / "v1" / "posts" / u32).map(|id: u32| Created(Json(id)));
+    let endpoint = path!(@get / "api" / "v1" / "posts" / u32).map(|id: u32| Created(Json(id)));
 
     let response = local::get("/api/v1/posts/42").respond(&endpoint);
     assert_eq!(response.status().as_u16(), 201);


### PR DESCRIPTION
* add new endpoints in `endpoint::syntax` (cdb4f39)
* add a macro `path!()` for building endpoints from segments (62e983e)
* rename `endpoint::error::AllowedMethods` to `endpoint::syntax::verb::Verbs` (cdb4f39)
* make `endpoints::path::*`, `endpoints::method::*` and `route!()` deprecated

Compatibility notes:
* `syntax::param()` and `syntax::remains()` treats parsing errors as a variant of `EndpointError`.