### PR TITLE
Tweak boxed endpoints

### DIFF
--- a/src/endpoint/boxed.rs
+++ b/src/endpoint/boxed.rs
@@ -31,29 +31,29 @@ impl<'e, E: SendEndpoint<'e>> FutureObjEndpoint<'e> for E {
 }
 
 #[allow(missing_docs)]
-pub struct Boxed<T: Tuple + 'static> {
+pub struct EndpointObj<T: Tuple + 'static> {
     inner: Box<dyn for<'a> FutureObjEndpoint<'a, Output = T> + Send + Sync + 'static>,
 }
 
-impl<T: Tuple + 'static> Boxed<T> {
+impl<T: Tuple + 'static> EndpointObj<T> {
     #[allow(missing_docs)]
-    pub fn new<E>(endpoint: E) -> Boxed<T>
+    pub fn new<E>(endpoint: E) -> EndpointObj<T>
     where
         for<'a> E: SendEndpoint<'a, Output = T> + Send + Sync + 'static,
     {
-        Boxed {
+        EndpointObj {
             inner: Box::new(endpoint),
         }
     }
 }
 
-impl<T: Tuple + 'static> fmt::Debug for Boxed<T> {
+impl<T: Tuple + 'static> fmt::Debug for EndpointObj<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.debug_struct("Boxed").finish()
+        formatter.debug_struct("EndpointObj").finish()
     }
 }
 
-impl<'e, T: Tuple + 'static> Endpoint<'e> for Boxed<T> {
+impl<'e, T: Tuple + 'static> Endpoint<'e> for EndpointObj<T> {
     type Output = T;
     type Future = FutureObj<'e, Result<T, Error>>;
 
@@ -88,29 +88,29 @@ impl<'e, E: Endpoint<'e>> LocalFutureObjEndpoint<'e> for E {
 }
 
 #[allow(missing_docs)]
-pub struct BoxedLocal<T: Tuple + 'static> {
+pub struct LocalEndpointObj<T: Tuple + 'static> {
     inner: Box<dyn for<'a> LocalFutureObjEndpoint<'a, Output = T> + 'static>,
 }
 
-impl<T: Tuple + 'static> BoxedLocal<T> {
+impl<T: Tuple + 'static> LocalEndpointObj<T> {
     #[allow(missing_docs)]
-    pub fn new<E>(endpoint: E) -> BoxedLocal<T>
+    pub fn new<E>(endpoint: E) -> LocalEndpointObj<T>
     where
         for<'a> E: Endpoint<'a, Output = T> + Send + Sync + 'static,
     {
-        BoxedLocal {
+        LocalEndpointObj {
             inner: Box::new(endpoint),
         }
     }
 }
 
-impl<T: Tuple + 'static> fmt::Debug for BoxedLocal<T> {
+impl<T: Tuple + 'static> fmt::Debug for LocalEndpointObj<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.debug_struct("BoxedLocal").finish()
+        formatter.debug_struct("LocalEndpointObj").finish()
     }
 }
 
-impl<'e, T: Tuple + 'static> Endpoint<'e> for BoxedLocal<T> {
+impl<'e, T: Tuple + 'static> Endpoint<'e> for LocalEndpointObj<T> {
     type Output = T;
     type Future = LocalFutureObj<'e, Result<T, Error>>;
 

--- a/src/endpoint/boxed.rs
+++ b/src/endpoint/boxed.rs
@@ -1,5 +1,3 @@
-#![allow(missing_docs)]
-
 use std::fmt;
 use std::pin::PinBox;
 
@@ -7,14 +5,10 @@ use futures_core::future::{FutureObj, LocalFutureObj};
 use futures_util::try_future::TryFutureExt;
 
 use crate::common::Tuple;
-use crate::endpoint::{Context, Endpoint, EndpointResult};
+use crate::endpoint::{Context, Endpoint, EndpointResult, SendEndpoint};
 use crate::error::Error;
 
-pub trait IntoBoxed<T>: for<'a> BoxedEndpoint<'a, Output = T> {}
-
-impl<T, E> IntoBoxed<T> for E where for<'a> E: BoxedEndpoint<'a, Output = T> {}
-
-pub trait BoxedEndpoint<'a>: Send + Sync + 'static {
+trait FutureObjEndpoint<'a>: 'a {
     type Output: Tuple;
 
     fn apply_obj(
@@ -23,27 +17,37 @@ pub trait BoxedEndpoint<'a>: Send + Sync + 'static {
     ) -> EndpointResult<FutureObj<'a, Result<Self::Output, Error>>>;
 }
 
-impl<'e, E> BoxedEndpoint<'e> for E
-where
-    E: Endpoint<'e> + Send + Sync + 'static,
-    E::Future: Send,
-{
+impl<'e, E: SendEndpoint<'e>> FutureObjEndpoint<'e> for E {
     type Output = E::Output;
 
+    #[inline(always)]
     fn apply_obj(
         &'e self,
         ecx: &mut Context<'_>,
     ) -> EndpointResult<FutureObj<'e, Result<Self::Output, Error>>> {
-        Ok(FutureObj::new(PinBox::new(self.apply(ecx)?.into_future())))
+        let future = self.apply(ecx)?.into_future();
+        Ok(FutureObj::new(PinBox::new(future)))
     }
 }
 
 #[allow(missing_docs)]
-pub struct Boxed<T> {
-    pub(super) inner: Box<dyn IntoBoxed<T, Output = T>>,
+pub struct Boxed<T: Tuple + 'static> {
+    inner: Box<dyn for<'a> FutureObjEndpoint<'a, Output = T> + Send + Sync + 'static>,
 }
 
-impl<T> fmt::Debug for Boxed<T> {
+impl<T: Tuple + 'static> Boxed<T> {
+    #[allow(missing_docs)]
+    pub fn new<E>(endpoint: E) -> Boxed<T>
+    where
+        for<'a> E: SendEndpoint<'a, Output = T> + Send + Sync + 'static,
+    {
+        Boxed {
+            inner: Box::new(endpoint),
+        }
+    }
+}
+
+impl<T: Tuple + 'static> fmt::Debug for Boxed<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.debug_struct("Boxed").finish()
     }
@@ -61,40 +65,46 @@ impl<'e, T: Tuple + 'static> Endpoint<'e> for Boxed<T> {
 
 // ==== BoxedLocal ====
 
-pub trait IntoBoxedLocal<T>: for<'a> LocalBoxedEndpoint<'a, Output = T> {}
-
-impl<T, E> IntoBoxedLocal<T> for E where for<'a> E: LocalBoxedEndpoint<'a, Output = T> {}
-
-pub trait LocalBoxedEndpoint<'a>: 'static {
+trait LocalFutureObjEndpoint<'a>: 'a {
     type Output: Tuple;
 
-    fn apply_obj(
+    fn apply_local_obj(
         &'a self,
         ecx: &mut Context<'_>,
     ) -> EndpointResult<LocalFutureObj<'a, Result<Self::Output, Error>>>;
 }
 
-impl<'e, E> LocalBoxedEndpoint<'e> for E
-where
-    E: Endpoint<'e> + 'static,
-{
+impl<'e, E: Endpoint<'e>> LocalFutureObjEndpoint<'e> for E {
     type Output = E::Output;
 
-    fn apply_obj(
+    #[inline(always)]
+    fn apply_local_obj(
         &'e self,
         ecx: &mut Context<'_>,
     ) -> EndpointResult<LocalFutureObj<'e, Result<Self::Output, Error>>> {
-        Ok(LocalFutureObj::new(PinBox::new(
-            self.apply(ecx)?.into_future(),
-        )))
+        let future = self.apply(ecx)?.into_future();
+        Ok(LocalFutureObj::new(PinBox::new(future)))
     }
 }
 
-pub struct BoxedLocal<T> {
-    pub(super) inner: Box<dyn IntoBoxedLocal<T, Output = T>>,
+#[allow(missing_docs)]
+pub struct BoxedLocal<T: Tuple + 'static> {
+    inner: Box<dyn for<'a> LocalFutureObjEndpoint<'a, Output = T> + 'static>,
 }
 
-impl<T> fmt::Debug for BoxedLocal<T> {
+impl<T: Tuple + 'static> BoxedLocal<T> {
+    #[allow(missing_docs)]
+    pub fn new<E>(endpoint: E) -> BoxedLocal<T>
+    where
+        for<'a> E: Endpoint<'a, Output = T> + Send + Sync + 'static,
+    {
+        BoxedLocal {
+            inner: Box::new(endpoint),
+        }
+    }
+}
+
+impl<T: Tuple + 'static> fmt::Debug for BoxedLocal<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.debug_struct("BoxedLocal").finish()
     }
@@ -106,6 +116,6 @@ impl<'e, T: Tuple + 'static> Endpoint<'e> for BoxedLocal<T> {
 
     #[inline(always)]
     fn apply(&'e self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
-        self.inner.apply_obj(ecx)
+        self.inner.apply_local_obj(ecx)
     }
 }

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -24,7 +24,7 @@ mod unit;
 mod value;
 
 // re-exports
-pub use self::boxed::{Boxed, BoxedLocal};
+pub use self::boxed::{EndpointObj, LocalEndpointObj};
 pub use self::context::Context;
 pub use self::error::{EndpointError, EndpointResult};
 pub use self::into_local::IntoLocal;

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -1,5 +1,6 @@
 //! Components for constructing `Endpoint`.
 
+mod boxed;
 mod context;
 pub mod error;
 mod into_local;
@@ -9,7 +10,6 @@ mod and;
 mod and_then;
 mod apply_fn;
 mod before_apply;
-mod boxed;
 mod fixed;
 mod lazy;
 mod map;
@@ -81,28 +81,6 @@ pub trait Endpoint<'a>: 'a {
         Self: Endpoint<'a, Output = T> + Sized,
     {
         self
-    }
-
-    /// Converts itself into an object which returns a `FutureObj`.
-    #[inline]
-    fn boxed<T: Tuple + 'static>(self) -> Boxed<T>
-    where
-        Self: self::boxed::IntoBoxed<T> + Sized,
-    {
-        (Boxed {
-            inner: Box::new(self),
-        }).with_output::<T>()
-    }
-
-    /// Converts itself into an object which returns a `LocalFutureObj`.
-    #[inline]
-    fn boxed_local<T: Tuple + 'static>(self) -> BoxedLocal<T>
-    where
-        Self: self::boxed::IntoBoxedLocal<T> + Sized,
-    {
-        (BoxedLocal {
-            inner: Box::new(self),
-        }).with_output::<T>()
     }
 }
 

--- a/tests/endpoint/boxed.rs
+++ b/tests/endpoint/boxed.rs
@@ -1,4 +1,4 @@
-use finchers::endpoint::Endpoint;
+use finchers::endpoint::{EndpointExt, EndpointObj, LocalEndpointObj};
 use finchers::local;
 use finchers::path;
 
@@ -7,7 +7,7 @@ use matches::assert_matches;
 #[test]
 fn test_boxed() {
     let endpoint = path!(@get /"foo");
-    let endpoint = endpoint.boxed::<()>();
+    let endpoint = EndpointObj::new(endpoint);
 
     assert_matches!(local::get("/foo").apply(&endpoint), Ok(()));
 }
@@ -15,7 +15,16 @@ fn test_boxed() {
 #[test]
 fn test_boxed_local() {
     let endpoint = path!(@get /"foo");
-    let endpoint = endpoint.boxed_local::<()>();
+    let endpoint = LocalEndpointObj::new(endpoint);
 
     assert_matches!(local::get("/foo").apply(&endpoint), Ok(..));
+}
+
+#[test]
+fn smoke_test() {
+    let endpoint = EndpointObj::new(path!(@get /"foo").map(|| "foo"));
+
+    drop(move || {
+        finchers::launch(endpoint).start("127.0.0.1:4000");
+    });
 }


### PR DESCRIPTION
* rename `Boxed<T>` and `BoxedLocal<T>` to `EndpointObj<T>` and `LocalEndpointObj<T>` (f443926)
* remove `Endpoint::boxed()` and `Endpoint::boxed_local()` (9738cfc)