### PR TITLE
Don't #[allow(type_alias_bounds)].

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -43,7 +43,6 @@ impl<'e, E: Endpoint<'e>> App<'e, E> {
     }
 }
 
-#[allow(type_alias_bounds)]
 pub type ResBody<T: Output> = Either<Once<String>, T::Body>;
 
 #[allow(missing_docs)]


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/54090 will fix false positives (maybe relevant?) and make it an error in the upcoming Rust 2018 edition, which means that if you want to migrate to Rust 2018, it shouldn't be ignored.

See also https://github.com/rust-lang/rust/issues/49441#issuecomment-421136550 for the decision and some background.