### PR TITLE
use the disambiguated paths in type alias instead of type_alias_bounds

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -43,7 +43,7 @@ impl<'e, E: Endpoint<'e>> App<'e, E> {
     }
 }
 
-pub type ResBody<T: Output> = Either<Once<String>, T::Body>;
+pub type ResBody<T> = Either<Once<String>, <T as Output>::Body>;
 
 #[allow(missing_docs)]
 #[derive(Debug)]


### PR DESCRIPTION
Note: In Rust 2018, the bounds in type alias will be treated as an error and some `#[allow(type_alias_bounds)]` was removed in #314.