### PR TITLE
bump version to 0.12.0-alpha.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finchers"
-version = "0.12.0-alpha.5" # don't forget to update html_root_url in lib.rs
+version = "0.12.0-alpha.6" # don't forget to update html_root_url in lib.rs
 edition = "2018"
 description = "A combinator library for builidng asynchronous HTTP services"
 authors = ["Yusuke Sasaki <yusuke.sasaki.nuem@gmail.com>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 //! }
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/finchers/0.12.0-alpha.5")]
+#![doc(html_root_url = "https://docs.rs/finchers/0.12.0-alpha.6")]
 #![warn(
     missing_docs,
     missing_debug_implementations,


### PR DESCRIPTION
* change the inner type of `EndpointError` for storing the custom error (49e5f5f)
* tweak the implementation of `SendEndpoint` (88fd590)
* add `payload::Optional<T>` (21af03e)
* replace `PinMut<Input` to `&mut Input` (d92a9b6)
* remove deprecated items (88fd590, 7dd6eda, a739efa)
* **switch the default toolchain to beta** (#322)

### Compatibility Notes
From this version, the dependency to `futures-preview` and the unstable lang features (`futures_api`, `pin`, and so on) are removed.  In order to use `async/await`, use the compatible layer of `futures-preview`.