### PR TITLE
bump version to 0.12.0-alpha.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finchers"
-version = "0.12.0-alpha.8-dev" # don't forget to update html_root_url in lib.rs
+version = "0.12.0-alpha.8" # don't forget to update html_root_url in lib.rs
 description = "A combinator library for builidng asynchronous HTTP services"
 authors = ["Yusuke Sasaki <yusuke.sasaki.nuem@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add this item to `Cargo.toml` in your project:
 
 ```toml
 [dependencies]
-finchers = "0.12.0-alpha.7"
+finchers = "0.12.0-alpha.8"
 ```
 
 # Documentation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,9 +37,9 @@
 //! ```
 
 // master
-#![doc(html_root_url = "https://finchers-rs.github.io/finchers/")]
+//#![doc(html_root_url = "https://finchers-rs.github.io/finchers/")]
 // released
-//#![doc(html_root_url = "https://finchers-rs.github.io/docs/finchers/v0.12.0-alpha.7")]
+#![doc(html_root_url = "https://finchers-rs.github.io/docs/finchers/v0.12.0-alpha.8")]
 #![warn(
     missing_docs,
     missing_debug_implementations,


### PR DESCRIPTION
* enable the feature 'secure' by default (ab6ecba)
* remove the module `input::cookie` (fe7231a)
* add missing local_inner_macros (#332)
* remove `input::query` and use serde_qs directly (49ef999)