### PR TITLE
reform the implementation around contexts

### DIFF
--- a/src/endpoint/and.rs
+++ b/src/endpoint/and.rs
@@ -6,7 +6,7 @@ use futures::future;
 use futures::{Future, Poll};
 
 use common::{Combine, Tuple};
-use endpoint::{ApplyContext, Endpoint, EndpointResult, IntoEndpoint};
+use endpoint::{ApplyContext, ApplyResult, Endpoint, IntoEndpoint};
 use error::Error;
 
 #[allow(missing_docs)]
@@ -25,7 +25,7 @@ where
     type Output = <E1::Output as Combine<E2::Output>>::Out;
     type Future = AndFuture<E1::Future, E2::Future>;
 
-    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         let f1 = self.e1.apply(ecx)?;
         let f2 = self.e2.apply(ecx)?;
         Ok(AndFuture { inner: f1.join(f2) })

--- a/src/endpoint/and.rs
+++ b/src/endpoint/and.rs
@@ -6,7 +6,7 @@ use futures::future;
 use futures::{Future, Poll};
 
 use common::{Combine, Tuple};
-use endpoint::{Context, Endpoint, EndpointResult, IntoEndpoint};
+use endpoint::{ApplyContext, Endpoint, EndpointResult, IntoEndpoint};
 use error::Error;
 
 #[allow(missing_docs)]
@@ -25,7 +25,7 @@ where
     type Output = <E1::Output as Combine<E2::Output>>::Out;
     type Future = AndFuture<E1::Future, E2::Future>;
 
-    fn apply(&'a self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         let f1 = self.e1.apply(ecx)?;
         let f2 = self.e2.apply(ecx)?;
         Ok(AndFuture { inner: f1.join(f2) })

--- a/src/endpoint/apply_fn.rs
+++ b/src/endpoint/apply_fn.rs
@@ -1,13 +1,13 @@
 use futures::future::IntoFuture;
 
 use common::Tuple;
-use endpoint::{Context, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, Endpoint, EndpointResult};
 use error::Error;
 
 /// Create an endpoint from a function.
 pub fn apply_fn<F, R>(f: F) -> ApplyFn<F>
 where
-    F: Fn(&mut Context<'_>) -> EndpointResult<R>,
+    F: Fn(&mut ApplyContext<'_>) -> EndpointResult<R>,
     R: IntoFuture<Error = Error>,
     R::Item: Tuple,
 {
@@ -22,7 +22,7 @@ pub struct ApplyFn<F> {
 
 impl<'a, F, R> Endpoint<'a> for ApplyFn<F>
 where
-    F: Fn(&mut Context<'_>) -> EndpointResult<R> + 'a,
+    F: Fn(&mut ApplyContext<'_>) -> EndpointResult<R> + 'a,
     R: IntoFuture<Error = Error> + 'a,
     R::Item: Tuple,
 {
@@ -30,7 +30,7 @@ where
     type Future = R::Future;
 
     #[inline]
-    fn apply(&'a self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         (self.f)(ecx).map(IntoFuture::into_future)
     }
 }

--- a/src/endpoint/apply_fn.rs
+++ b/src/endpoint/apply_fn.rs
@@ -1,13 +1,13 @@
 use futures::future::IntoFuture;
 
 use common::Tuple;
-use endpoint::{ApplyContext, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, ApplyResult, Endpoint};
 use error::Error;
 
 /// Create an endpoint from a function.
 pub fn apply_fn<F, R>(f: F) -> ApplyFn<F>
 where
-    F: Fn(&mut ApplyContext<'_>) -> EndpointResult<R>,
+    F: Fn(&mut ApplyContext<'_>) -> ApplyResult<R>,
     R: IntoFuture<Error = Error>,
     R::Item: Tuple,
 {
@@ -22,7 +22,7 @@ pub struct ApplyFn<F> {
 
 impl<'a, F, R> Endpoint<'a> for ApplyFn<F>
 where
-    F: Fn(&mut ApplyContext<'_>) -> EndpointResult<R> + 'a,
+    F: Fn(&mut ApplyContext<'_>) -> ApplyResult<R> + 'a,
     R: IntoFuture<Error = Error> + 'a,
     R::Item: Tuple,
 {
@@ -30,7 +30,7 @@ where
     type Future = R::Future;
 
     #[inline]
-    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         (self.f)(ecx).map(IntoFuture::into_future)
     }
 }

--- a/src/endpoint/boxed.rs
+++ b/src/endpoint/boxed.rs
@@ -2,7 +2,7 @@ use futures::Future;
 use std::fmt;
 
 use common::Tuple;
-use endpoint::{ApplyContext, Endpoint, EndpointResult, IsSendEndpoint};
+use endpoint::{ApplyContext, ApplyResult, Endpoint, IsSendEndpoint};
 use error::Error;
 
 trait FutureObjEndpoint<'a>: 'a {
@@ -11,7 +11,7 @@ trait FutureObjEndpoint<'a>: 'a {
     fn apply_obj(
         &'a self,
         ecx: &mut ApplyContext<'_>,
-    ) -> EndpointResult<Box<dyn Future<Item = Self::Output, Error = Error> + Send + 'a>>;
+    ) -> ApplyResult<Box<dyn Future<Item = Self::Output, Error = Error> + Send + 'a>>;
 }
 
 impl<'e, E: IsSendEndpoint<'e>> FutureObjEndpoint<'e> for E {
@@ -21,7 +21,7 @@ impl<'e, E: IsSendEndpoint<'e>> FutureObjEndpoint<'e> for E {
     fn apply_obj(
         &'e self,
         ecx: &mut ApplyContext<'_>,
-    ) -> EndpointResult<Box<dyn Future<Item = Self::Output, Error = Error> + Send + 'e>> {
+    ) -> ApplyResult<Box<dyn Future<Item = Self::Output, Error = Error> + Send + 'e>> {
         let future = self.apply(ecx)?;
         Ok(Box::new(future))
     }
@@ -55,7 +55,7 @@ impl<'e, T: Tuple + 'static> Endpoint<'e> for EndpointObj<T> {
     type Future = Box<dyn Future<Item = Self::Output, Error = Error> + Send + 'e>;
 
     #[inline(always)]
-    fn apply(&'e self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'e self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         self.inner.apply_obj(ecx)
     }
 }
@@ -68,7 +68,7 @@ trait LocalFutureObjEndpoint<'a>: 'a {
     fn apply_local_obj(
         &'a self,
         ecx: &mut ApplyContext<'_>,
-    ) -> EndpointResult<Box<dyn Future<Item = Self::Output, Error = Error> + 'a>>;
+    ) -> ApplyResult<Box<dyn Future<Item = Self::Output, Error = Error> + 'a>>;
 }
 
 impl<'e, E: Endpoint<'e>> LocalFutureObjEndpoint<'e> for E {
@@ -78,7 +78,7 @@ impl<'e, E: Endpoint<'e>> LocalFutureObjEndpoint<'e> for E {
     fn apply_local_obj(
         &'e self,
         ecx: &mut ApplyContext<'_>,
-    ) -> EndpointResult<Box<dyn Future<Item = Self::Output, Error = Error> + 'e>> {
+    ) -> ApplyResult<Box<dyn Future<Item = Self::Output, Error = Error> + 'e>> {
         let future = self.apply(ecx)?;
         Ok(Box::new(future))
     }
@@ -112,7 +112,7 @@ impl<'e, T: Tuple + 'static> Endpoint<'e> for LocalEndpointObj<T> {
     type Future = Box<dyn Future<Item = Self::Output, Error = Error> + 'e>;
 
     #[inline(always)]
-    fn apply(&'e self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'e self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         self.inner.apply_local_obj(ecx)
     }
 }

--- a/src/endpoint/boxed.rs
+++ b/src/endpoint/boxed.rs
@@ -2,7 +2,7 @@ use futures::Future;
 use std::fmt;
 
 use common::Tuple;
-use endpoint::{Context, Endpoint, EndpointResult, IsSendEndpoint};
+use endpoint::{ApplyContext, Endpoint, EndpointResult, IsSendEndpoint};
 use error::Error;
 
 trait FutureObjEndpoint<'a>: 'a {
@@ -10,7 +10,7 @@ trait FutureObjEndpoint<'a>: 'a {
 
     fn apply_obj(
         &'a self,
-        ecx: &mut Context<'_>,
+        ecx: &mut ApplyContext<'_>,
     ) -> EndpointResult<Box<dyn Future<Item = Self::Output, Error = Error> + Send + 'a>>;
 }
 
@@ -20,7 +20,7 @@ impl<'e, E: IsSendEndpoint<'e>> FutureObjEndpoint<'e> for E {
     #[inline(always)]
     fn apply_obj(
         &'e self,
-        ecx: &mut Context<'_>,
+        ecx: &mut ApplyContext<'_>,
     ) -> EndpointResult<Box<dyn Future<Item = Self::Output, Error = Error> + Send + 'e>> {
         let future = self.apply(ecx)?;
         Ok(Box::new(future))
@@ -55,7 +55,7 @@ impl<'e, T: Tuple + 'static> Endpoint<'e> for EndpointObj<T> {
     type Future = Box<dyn Future<Item = Self::Output, Error = Error> + Send + 'e>;
 
     #[inline(always)]
-    fn apply(&'e self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'e self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         self.inner.apply_obj(ecx)
     }
 }
@@ -67,7 +67,7 @@ trait LocalFutureObjEndpoint<'a>: 'a {
 
     fn apply_local_obj(
         &'a self,
-        ecx: &mut Context<'_>,
+        ecx: &mut ApplyContext<'_>,
     ) -> EndpointResult<Box<dyn Future<Item = Self::Output, Error = Error> + 'a>>;
 }
 
@@ -77,7 +77,7 @@ impl<'e, E: Endpoint<'e>> LocalFutureObjEndpoint<'e> for E {
     #[inline(always)]
     fn apply_local_obj(
         &'e self,
-        ecx: &mut Context<'_>,
+        ecx: &mut ApplyContext<'_>,
     ) -> EndpointResult<Box<dyn Future<Item = Self::Output, Error = Error> + 'e>> {
         let future = self.apply(ecx)?;
         Ok(Box::new(future))
@@ -112,7 +112,7 @@ impl<'e, T: Tuple + 'static> Endpoint<'e> for LocalEndpointObj<T> {
     type Future = Box<dyn Future<Item = Self::Output, Error = Error> + 'e>;
 
     #[inline(always)]
-    fn apply(&'e self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'e self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         self.inner.apply_local_obj(ecx)
     }
 }

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -1,7 +1,7 @@
 //! Components for constructing `Endpoint`.
 
 mod boxed;
-mod context;
+pub mod context;
 pub mod error;
 pub mod syntax;
 pub mod wrapper;
@@ -15,7 +15,8 @@ mod value;
 
 // re-exports
 pub use self::boxed::{EndpointObj, LocalEndpointObj};
-pub use self::context::Context;
+pub use self::context::{with_get_cx, ApplyContext, TaskContext};
+pub(crate) use self::context::{with_set_cx, Cursor};
 pub use self::error::{EndpointError, EndpointResult};
 pub use self::wrapper::{EndpointWrapExt, Wrapper};
 
@@ -26,6 +27,13 @@ pub use self::or_strict::OrStrict;
 pub use self::apply_fn::{apply_fn, ApplyFn};
 pub use self::unit::{unit, Unit};
 pub use self::value::{value, Value};
+
+#[doc(hidden)]
+#[deprecated(
+    since = "0.12.0-alpha.9",
+    note = "renamed to `ApplyContext`."
+)]
+pub type Context<'a> = ApplyContext<'a>;
 
 // ====
 
@@ -47,7 +55,7 @@ pub trait Endpoint<'a>: 'a {
 
     /// Perform checking the incoming HTTP request and returns
     /// an instance of the associated Future if matched.
-    fn apply(&'a self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future>;
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future>;
 
     /// Add an annotation that the associated type `Output` is fixed to `T`.
     #[inline(always)]
@@ -72,7 +80,7 @@ impl<'a, E: Endpoint<'a>> Endpoint<'a> for Box<E> {
     type Output = E::Output;
     type Future = E::Future;
 
-    fn apply(&'a self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         (**self).apply(ecx)
     }
 }
@@ -81,7 +89,7 @@ impl<'a, E: Endpoint<'a>> Endpoint<'a> for Rc<E> {
     type Output = E::Output;
     type Future = E::Future;
 
-    fn apply(&'a self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         (**self).apply(ecx)
     }
 }
@@ -90,7 +98,7 @@ impl<'a, E: Endpoint<'a>> Endpoint<'a> for Arc<E> {
     type Output = E::Output;
     type Future = E::Future;
 
-    fn apply(&'a self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         (**self).apply(ecx)
     }
 }
@@ -103,7 +111,7 @@ pub trait IsSendEndpoint<'a>: 'a + sealed_is_send_endpoint::Sealed {
     #[doc(hidden)]
     type Future: Future<Item = Self::Output, Error = Error> + Send + 'a;
     #[doc(hidden)]
-    fn apply(&'a self, cx: &mut Context<'_>) -> EndpointResult<Self::Future>;
+    fn apply(&'a self, cx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future>;
 }
 
 mod sealed_is_send_endpoint {
@@ -128,7 +136,7 @@ where
     type Future = E::Future;
 
     #[inline(always)]
-    fn apply(&'a self, cx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, cx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         self.apply(cx)
     }
 }
@@ -154,7 +162,7 @@ impl<'a, E: IsSendEndpoint<'a>> Endpoint<'a> for SendEndpoint<E> {
     type Future = E::Future;
 
     #[inline(always)]
-    fn apply(&'a self, cx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, cx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         self.endpoint.apply(cx)
     }
 }

--- a/src/endpoint/or.rs
+++ b/src/endpoint/or.rs
@@ -3,7 +3,7 @@ use either::Either::*;
 use http::Response;
 use std::mem;
 
-use endpoint::{ApplyContext, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, ApplyResult, Endpoint};
 use error::Error;
 use output::{Output, OutputContext};
 
@@ -22,7 +22,7 @@ where
     type Output = (Wrapped<E1::Output, E2::Output>,);
     type Future = OrFuture<E1::Future, E2::Future>;
 
-    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         let orig_cursor = ecx.cursor().clone();
         match self.e1.apply(ecx) {
             Ok(future1) => {

--- a/src/endpoint/or_strict.rs
+++ b/src/endpoint/or_strict.rs
@@ -1,6 +1,6 @@
 use either::Either;
 
-use endpoint::{ApplyContext, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, ApplyResult, Endpoint};
 use error::Error;
 
 #[allow(missing_docs)]
@@ -18,7 +18,7 @@ where
     type Output = E1::Output;
     type Future = OrStrictFuture<E1::Future, E2::Future>;
 
-    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         let orig_cursor = ecx.cursor().clone();
         match self.e1.apply(ecx) {
             Ok(future1) => {

--- a/src/endpoint/or_strict.rs
+++ b/src/endpoint/or_strict.rs
@@ -1,6 +1,6 @@
 use either::Either;
 
-use endpoint::{Context, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, Endpoint, EndpointResult};
 use error::Error;
 
 #[allow(missing_docs)]
@@ -18,15 +18,11 @@ where
     type Output = E1::Output;
     type Future = OrStrictFuture<E1::Future, E2::Future>;
 
-    fn apply(&'a self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
-        match {
-            let mut ecx = ecx.clone_reborrowed();
-            self.e1
-                .apply(&mut ecx)
-                .map(|future| (future, ecx.current_cursor()))
-        } {
-            Ok((future1, cursor1)) => {
-                ecx.reset_cursor(cursor1);
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+        let orig_cursor = ecx.cursor().clone();
+        match self.e1.apply(ecx) {
+            Ok(future1) => {
+                *ecx.cursor() = orig_cursor;
                 Ok(OrStrictFuture::left(future1))
             }
             Err(err1) => match self.e2.apply(ecx) {

--- a/src/endpoint/syntax/mod.rs
+++ b/src/endpoint/syntax/mod.rs
@@ -9,7 +9,7 @@ use std::marker::PhantomData;
 
 use percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
 
-use endpoint::{Context, Endpoint, EndpointError, EndpointResult, IntoEndpoint};
+use endpoint::{ApplyContext, Endpoint, EndpointError, EndpointResult, IntoEndpoint};
 use error;
 use error::Error;
 use input::FromEncodedStr;
@@ -77,7 +77,7 @@ impl<'a> Endpoint<'a> for MatchSegment {
     type Output = ();
     type Future = Matched;
 
-    fn apply(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         let s = ecx.next_segment().ok_or_else(EndpointError::not_matched)?;
         if s == self.encoded {
             Ok(Matched { _priv: () })
@@ -135,7 +135,7 @@ impl<'a> Endpoint<'a> for MatchEos {
     type Output = ();
     type Future = Matched;
 
-    fn apply(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         match ecx.next_segment() {
             None => Ok(Matched { _priv: () }),
             Some(..) => Err(EndpointError::not_matched()),
@@ -186,7 +186,7 @@ where
     type Output = (T,);
     type Future = Extracted<T>;
 
-    fn apply(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         let s = ecx.next_segment().ok_or_else(EndpointError::not_matched)?;
         let x =
             T::from_encoded_str(s).map_err(|err| EndpointError::custom(error::bad_request(err)))?;
@@ -236,7 +236,7 @@ where
     type Output = (T,);
     type Future = Extracted<T>;
 
-    fn apply(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         let result = T::from_encoded_str(ecx.remaining_path())
             .map_err(|err| EndpointError::custom(error::bad_request(err)));
         while let Some(..) = ecx.next_segment() {}

--- a/src/endpoint/syntax/verb.rs
+++ b/src/endpoint/syntax/verb.rs
@@ -3,7 +3,7 @@ use std::ops::{BitOr, BitOrAssign};
 use http::Method;
 
 use super::Matched;
-use endpoint::{Context, Endpoint, EndpointError, EndpointResult};
+use endpoint::{ApplyContext, Endpoint, EndpointError, EndpointResult};
 
 /// Create an endpoint which checks if the verb of current request
 /// is equal to the specified value.
@@ -21,7 +21,7 @@ impl<'a> Endpoint<'a> for MatchVerbs {
     type Output = ();
     type Future = Matched;
 
-    fn apply(&'a self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         if self.allowed.contains(ecx.input().method()) {
             Ok(Matched { _priv: () })
         } else {
@@ -54,7 +54,7 @@ macro_rules! define_verbs {
             type Future = Matched;
 
             #[inline]
-            fn apply(&'e self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+            fn apply(&'e self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
                 if *ecx.input().method() == Method::$METHOD {
                     Ok(Matched { _priv: () })
                 } else {

--- a/src/endpoint/syntax/verb.rs
+++ b/src/endpoint/syntax/verb.rs
@@ -3,7 +3,7 @@ use std::ops::{BitOr, BitOrAssign};
 use http::Method;
 
 use super::Matched;
-use endpoint::{ApplyContext, Endpoint, EndpointError, EndpointResult};
+use endpoint::{ApplyContext, ApplyError, ApplyResult, Endpoint};
 
 /// Create an endpoint which checks if the verb of current request
 /// is equal to the specified value.
@@ -21,11 +21,11 @@ impl<'a> Endpoint<'a> for MatchVerbs {
     type Output = ();
     type Future = Matched;
 
-    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         if self.allowed.contains(ecx.input().method()) {
             Ok(Matched { _priv: () })
         } else {
-            Err(EndpointError::method_not_allowed(self.allowed))
+            Err(ApplyError::method_not_allowed(self.allowed))
         }
     }
 }
@@ -54,11 +54,11 @@ macro_rules! define_verbs {
             type Future = Matched;
 
             #[inline]
-            fn apply(&'e self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+            fn apply(&'e self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
                 if *ecx.input().method() == Method::$METHOD {
                     Ok(Matched { _priv: () })
                 } else {
-                    Err(EndpointError::method_not_allowed(Verbs::$METHOD))
+                    Err(ApplyError::method_not_allowed(Verbs::$METHOD))
                 }
             }
         }

--- a/src/endpoint/unit.rs
+++ b/src/endpoint/unit.rs
@@ -1,4 +1,4 @@
-use endpoint::{ApplyContext, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, ApplyResult, Endpoint};
 use error::Error;
 
 /// Create an endpoint which simply returns an unit (`()`).
@@ -18,7 +18,7 @@ impl<'a> Endpoint<'a> for Unit {
     type Future = UnitFuture;
 
     #[inline]
-    fn apply(&'a self, _: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, _: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         Ok(UnitFuture { _priv: () })
     }
 }

--- a/src/endpoint/unit.rs
+++ b/src/endpoint/unit.rs
@@ -1,4 +1,4 @@
-use endpoint::{Context, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, Endpoint, EndpointResult};
 use error::Error;
 
 /// Create an endpoint which simply returns an unit (`()`).
@@ -18,7 +18,7 @@ impl<'a> Endpoint<'a> for Unit {
     type Future = UnitFuture;
 
     #[inline]
-    fn apply(&'a self, _: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, _: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         Ok(UnitFuture { _priv: () })
     }
 }

--- a/src/endpoint/value.rs
+++ b/src/endpoint/value.rs
@@ -1,4 +1,4 @@
-use endpoint::{ApplyContext, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, ApplyResult, Endpoint};
 use error::Error;
 
 /// Create an endpoint which simply clones the specified value.
@@ -48,7 +48,7 @@ impl<'a, T: Clone + 'a> Endpoint<'a> for Value<T> {
     type Output = (T,);
     type Future = ValueFuture<'a, T>;
 
-    fn apply(&'a self, _: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, _: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         Ok(ValueFuture { x: &self.x })
     }
 }

--- a/src/endpoint/value.rs
+++ b/src/endpoint/value.rs
@@ -1,4 +1,4 @@
-use endpoint::{Context, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, Endpoint, EndpointResult};
 use error::Error;
 
 /// Create an endpoint which simply clones the specified value.
@@ -48,7 +48,7 @@ impl<'a, T: Clone + 'a> Endpoint<'a> for Value<T> {
     type Output = (T,);
     type Future = ValueFuture<'a, T>;
 
-    fn apply(&'a self, _: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, _: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         Ok(ValueFuture { x: &self.x })
     }
 }

--- a/src/endpoint/wrapper/after_apply.rs
+++ b/src/endpoint/wrapper/after_apply.rs
@@ -1,11 +1,11 @@
 use super::Wrapper;
-use endpoint::{Context, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, Endpoint, EndpointResult};
 
 /// Creates a wrapper for creating an endpoint which runs the provided function
 /// after calling `Endpoint::apply()`.
 pub fn after_apply<F>(f: F) -> AfterApply<F>
 where
-    F: Fn(&mut Context<'_>) -> EndpointResult<()>,
+    F: Fn(&mut ApplyContext<'_>) -> EndpointResult<()>,
 {
     AfterApply { f }
 }
@@ -19,7 +19,7 @@ pub struct AfterApply<F> {
 impl<'a, E, F> Wrapper<'a, E> for AfterApply<F>
 where
     E: Endpoint<'a>,
-    F: Fn(&mut Context<'_>) -> EndpointResult<()> + 'a,
+    F: Fn(&mut ApplyContext<'_>) -> EndpointResult<()> + 'a,
 {
     type Output = E::Output;
     type Endpoint = AfterApplyEndpoint<E, F>;
@@ -42,13 +42,13 @@ pub struct AfterApplyEndpoint<E, F> {
 impl<'a, E, F> Endpoint<'a> for AfterApplyEndpoint<E, F>
 where
     E: Endpoint<'a>,
-    F: Fn(&mut Context<'_>) -> EndpointResult<()> + 'a,
+    F: Fn(&mut ApplyContext<'_>) -> EndpointResult<()> + 'a,
 {
     type Output = E::Output;
     type Future = E::Future;
 
     #[inline]
-    fn apply(&'a self, cx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, cx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         let future = self.endpoint.apply(cx)?;
         (self.f)(cx)?;
         Ok(future)

--- a/src/endpoint/wrapper/after_apply.rs
+++ b/src/endpoint/wrapper/after_apply.rs
@@ -1,11 +1,11 @@
 use super::Wrapper;
-use endpoint::{ApplyContext, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, ApplyResult, Endpoint};
 
 /// Creates a wrapper for creating an endpoint which runs the provided function
 /// after calling `Endpoint::apply()`.
 pub fn after_apply<F>(f: F) -> AfterApply<F>
 where
-    F: Fn(&mut ApplyContext<'_>) -> EndpointResult<()>,
+    F: Fn(&mut ApplyContext<'_>) -> ApplyResult<()>,
 {
     AfterApply { f }
 }
@@ -19,7 +19,7 @@ pub struct AfterApply<F> {
 impl<'a, E, F> Wrapper<'a, E> for AfterApply<F>
 where
     E: Endpoint<'a>,
-    F: Fn(&mut ApplyContext<'_>) -> EndpointResult<()> + 'a,
+    F: Fn(&mut ApplyContext<'_>) -> ApplyResult<()> + 'a,
 {
     type Output = E::Output;
     type Endpoint = AfterApplyEndpoint<E, F>;
@@ -42,13 +42,13 @@ pub struct AfterApplyEndpoint<E, F> {
 impl<'a, E, F> Endpoint<'a> for AfterApplyEndpoint<E, F>
 where
     E: Endpoint<'a>,
-    F: Fn(&mut ApplyContext<'_>) -> EndpointResult<()> + 'a,
+    F: Fn(&mut ApplyContext<'_>) -> ApplyResult<()> + 'a,
 {
     type Output = E::Output;
     type Future = E::Future;
 
     #[inline]
-    fn apply(&'a self, cx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, cx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         let future = self.endpoint.apply(cx)?;
         (self.f)(cx)?;
         Ok(future)

--- a/src/endpoint/wrapper/and_then.rs
+++ b/src/endpoint/wrapper/and_then.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use futures::{Future, IntoFuture, Poll};
 
 use common::{Func, Tuple};
-use endpoint::{ApplyContext, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, ApplyResult, Endpoint};
 use error::Error;
 
 use super::try_chain::{TryChain, TryChainAction};
@@ -62,7 +62,7 @@ where
     type Output = (<F::Out as IntoFuture>::Item,);
     type Future = AndThenFuture<'a, E::Future, F::Out, F>;
 
-    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         let f1 = self.endpoint.apply(ecx)?;
         Ok(AndThenFuture {
             try_chain: TryChain::new(f1, &self.f),

--- a/src/endpoint/wrapper/and_then.rs
+++ b/src/endpoint/wrapper/and_then.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use futures::{Future, IntoFuture, Poll};
 
 use common::{Func, Tuple};
-use endpoint::{Context, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, Endpoint, EndpointResult};
 use error::Error;
 
 use super::try_chain::{TryChain, TryChainAction};
@@ -62,7 +62,7 @@ where
     type Output = (<F::Out as IntoFuture>::Item,);
     type Future = AndThenFuture<'a, E::Future, F::Out, F>;
 
-    fn apply(&'a self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         let f1 = self.endpoint.apply(ecx)?;
         Ok(AndThenFuture {
             try_chain: TryChain::new(f1, &self.f),

--- a/src/endpoint/wrapper/before_apply.rs
+++ b/src/endpoint/wrapper/before_apply.rs
@@ -1,11 +1,11 @@
 use super::Wrapper;
-use endpoint::{Context, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, Endpoint, EndpointResult};
 
 /// Creates a wrapper for creating an endpoint which runs the provided function
 /// before calling `Endpoint::apply()`.
 pub fn before_apply<F>(f: F) -> BeforeApply<F>
 where
-    F: Fn(&mut Context<'_>) -> EndpointResult<()>,
+    F: Fn(&mut ApplyContext<'_>) -> EndpointResult<()>,
 {
     BeforeApply { f }
 }
@@ -19,7 +19,7 @@ pub struct BeforeApply<F> {
 impl<'a, E, F> Wrapper<'a, E> for BeforeApply<F>
 where
     E: Endpoint<'a>,
-    F: Fn(&mut Context<'_>) -> EndpointResult<()> + 'a,
+    F: Fn(&mut ApplyContext<'_>) -> EndpointResult<()> + 'a,
 {
     type Output = E::Output;
     type Endpoint = BeforeApplyEndpoint<E, F>;
@@ -42,13 +42,13 @@ pub struct BeforeApplyEndpoint<E, F> {
 impl<'a, E, F> Endpoint<'a> for BeforeApplyEndpoint<E, F>
 where
     E: Endpoint<'a>,
-    F: Fn(&mut Context<'_>) -> EndpointResult<()> + 'a,
+    F: Fn(&mut ApplyContext<'_>) -> EndpointResult<()> + 'a,
 {
     type Output = E::Output;
     type Future = E::Future;
 
     #[inline]
-    fn apply(&'a self, cx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, cx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         (self.f)(cx)?;
         self.endpoint.apply(cx)
     }

--- a/src/endpoint/wrapper/before_apply.rs
+++ b/src/endpoint/wrapper/before_apply.rs
@@ -1,11 +1,11 @@
 use super::Wrapper;
-use endpoint::{ApplyContext, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, ApplyResult, Endpoint};
 
 /// Creates a wrapper for creating an endpoint which runs the provided function
 /// before calling `Endpoint::apply()`.
 pub fn before_apply<F>(f: F) -> BeforeApply<F>
 where
-    F: Fn(&mut ApplyContext<'_>) -> EndpointResult<()>,
+    F: Fn(&mut ApplyContext<'_>) -> ApplyResult<()>,
 {
     BeforeApply { f }
 }
@@ -19,7 +19,7 @@ pub struct BeforeApply<F> {
 impl<'a, E, F> Wrapper<'a, E> for BeforeApply<F>
 where
     E: Endpoint<'a>,
-    F: Fn(&mut ApplyContext<'_>) -> EndpointResult<()> + 'a,
+    F: Fn(&mut ApplyContext<'_>) -> ApplyResult<()> + 'a,
 {
     type Output = E::Output;
     type Endpoint = BeforeApplyEndpoint<E, F>;
@@ -42,13 +42,13 @@ pub struct BeforeApplyEndpoint<E, F> {
 impl<'a, E, F> Endpoint<'a> for BeforeApplyEndpoint<E, F>
 where
     E: Endpoint<'a>,
-    F: Fn(&mut ApplyContext<'_>) -> EndpointResult<()> + 'a,
+    F: Fn(&mut ApplyContext<'_>) -> ApplyResult<()> + 'a,
 {
     type Output = E::Output;
     type Future = E::Future;
 
     #[inline]
-    fn apply(&'a self, cx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, cx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         (self.f)(cx)?;
         self.endpoint.apply(cx)
     }

--- a/src/endpoint/wrapper/map.rs
+++ b/src/endpoint/wrapper/map.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use futures::{Future, Poll};
 
 use common::{Func, Tuple};
-use endpoint::{Context, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, Endpoint, EndpointResult};
 use error::Error;
 
 use super::Wrapper;
@@ -59,7 +59,7 @@ where
     type Future = MapFuture<'a, E::Future, F>;
 
     #[inline]
-    fn apply(&'a self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         Ok(MapFuture {
             future: self.endpoint.apply(ecx)?,
             f: Some(&self.f),

--- a/src/endpoint/wrapper/map.rs
+++ b/src/endpoint/wrapper/map.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use futures::{Future, Poll};
 
 use common::{Func, Tuple};
-use endpoint::{ApplyContext, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, ApplyResult, Endpoint};
 use error::Error;
 
 use super::Wrapper;
@@ -59,7 +59,7 @@ where
     type Future = MapFuture<'a, E::Future, F>;
 
     #[inline]
-    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         Ok(MapFuture {
             future: self.endpoint.apply(ecx)?,
             f: Some(&self.f),

--- a/src/endpoint/wrapper/or_reject.rs
+++ b/src/endpoint/wrapper/or_reject.rs
@@ -1,6 +1,6 @@
 use futures::{Future, Poll};
 
-use endpoint::{ApplyContext, Endpoint, EndpointError, EndpointResult};
+use endpoint::{ApplyContext, ApplyError, ApplyResult, Endpoint};
 use error::Error;
 
 use super::Wrapper;
@@ -35,7 +35,7 @@ impl<'a, E: Endpoint<'a>> Endpoint<'a> for OrRejectEndpoint<E> {
     type Output = E::Output;
     type Future = OrRejectFuture<E::Future>;
 
-    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         match self.endpoint.apply(ecx) {
             Ok(future) => Ok(OrRejectFuture { inner: Ok(future) }),
             Err(err) => {
@@ -75,7 +75,7 @@ where
 /// the return value from the associated `Future`.
 pub fn or_reject_with<F, R>(f: F) -> OrRejectWith<F>
 where
-    F: Fn(EndpointError, &mut ApplyContext<'_>) -> R,
+    F: Fn(ApplyError, &mut ApplyContext<'_>) -> R,
     R: Into<Error>,
 {
     OrRejectWith { f }
@@ -90,7 +90,7 @@ pub struct OrRejectWith<F> {
 impl<'a, E, F, R> Wrapper<'a, E> for OrRejectWith<F>
 where
     E: Endpoint<'a>,
-    F: Fn(EndpointError, &mut ApplyContext<'_>) -> R + 'a,
+    F: Fn(ApplyError, &mut ApplyContext<'_>) -> R + 'a,
     R: Into<Error> + 'a,
 {
     type Output = E::Output;
@@ -113,13 +113,13 @@ pub struct OrRejectWithEndpoint<E, F> {
 impl<'a, E, F, R> Endpoint<'a> for OrRejectWithEndpoint<E, F>
 where
     E: Endpoint<'a>,
-    F: Fn(EndpointError, &mut ApplyContext<'_>) -> R + 'a,
+    F: Fn(ApplyError, &mut ApplyContext<'_>) -> R + 'a,
     R: Into<Error> + 'a,
 {
     type Output = E::Output;
     type Future = OrRejectFuture<E::Future>;
 
-    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         match self.endpoint.apply(ecx) {
             Ok(future) => Ok(OrRejectFuture { inner: Ok(future) }),
             Err(err) => {

--- a/src/endpoint/wrapper/or_reject.rs
+++ b/src/endpoint/wrapper/or_reject.rs
@@ -1,6 +1,6 @@
 use futures::{Future, Poll};
 
-use endpoint::{Context, Endpoint, EndpointError, EndpointResult};
+use endpoint::{ApplyContext, Endpoint, EndpointError, EndpointResult};
 use error::Error;
 
 use super::Wrapper;
@@ -35,7 +35,7 @@ impl<'a, E: Endpoint<'a>> Endpoint<'a> for OrRejectEndpoint<E> {
     type Output = E::Output;
     type Future = OrRejectFuture<E::Future>;
 
-    fn apply(&'a self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         match self.endpoint.apply(ecx) {
             Ok(future) => Ok(OrRejectFuture { inner: Ok(future) }),
             Err(err) => {
@@ -75,7 +75,7 @@ where
 /// the return value from the associated `Future`.
 pub fn or_reject_with<F, R>(f: F) -> OrRejectWith<F>
 where
-    F: Fn(EndpointError, &mut Context<'_>) -> R,
+    F: Fn(EndpointError, &mut ApplyContext<'_>) -> R,
     R: Into<Error>,
 {
     OrRejectWith { f }
@@ -90,7 +90,7 @@ pub struct OrRejectWith<F> {
 impl<'a, E, F, R> Wrapper<'a, E> for OrRejectWith<F>
 where
     E: Endpoint<'a>,
-    F: Fn(EndpointError, &mut Context<'_>) -> R + 'a,
+    F: Fn(EndpointError, &mut ApplyContext<'_>) -> R + 'a,
     R: Into<Error> + 'a,
 {
     type Output = E::Output;
@@ -113,13 +113,13 @@ pub struct OrRejectWithEndpoint<E, F> {
 impl<'a, E, F, R> Endpoint<'a> for OrRejectWithEndpoint<E, F>
 where
     E: Endpoint<'a>,
-    F: Fn(EndpointError, &mut Context<'_>) -> R + 'a,
+    F: Fn(EndpointError, &mut ApplyContext<'_>) -> R + 'a,
     R: Into<Error> + 'a,
 {
     type Output = E::Output;
     type Future = OrRejectFuture<E::Future>;
 
-    fn apply(&'a self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         match self.endpoint.apply(ecx) {
             Ok(future) => Ok(OrRejectFuture { inner: Ok(future) }),
             Err(err) => {

--- a/src/endpoint/wrapper/recover.rs
+++ b/src/endpoint/wrapper/recover.rs
@@ -2,7 +2,7 @@ use either::Either;
 use futures::{Async, Future, Poll};
 use http::Response;
 
-use endpoint::{Context, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, Endpoint, EndpointResult};
 use error::Error;
 use output::{Output, OutputContext};
 
@@ -55,7 +55,7 @@ where
     type Output = (Recovered<E::Output, R::Item>,);
     type Future = RecoverFuture<E::Future, R, &'a F>;
 
-    fn apply(&'a self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         let f1 = self.endpoint.apply(ecx)?;
         Ok(RecoverFuture {
             try_chain: TryChain::new(f1, &self.f),

--- a/src/endpoint/wrapper/recover.rs
+++ b/src/endpoint/wrapper/recover.rs
@@ -2,7 +2,7 @@ use either::Either;
 use futures::{Async, Future, Poll};
 use http::Response;
 
-use endpoint::{ApplyContext, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, ApplyResult, Endpoint};
 use error::Error;
 use output::{Output, OutputContext};
 
@@ -55,7 +55,7 @@ where
     type Output = (Recovered<E::Output, R::Item>,);
     type Future = RecoverFuture<E::Future, R, &'a F>;
 
-    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         let f1 = self.endpoint.apply(ecx)?;
         Ok(RecoverFuture {
             try_chain: TryChain::new(f1, &self.f),

--- a/src/endpoints/body.rs
+++ b/src/endpoints/body.rs
@@ -11,10 +11,9 @@ use http::StatusCode;
 use hyper::body::{Body, Payload};
 use serde::de::DeserializeOwned;
 
-use endpoint::{Context, Endpoint, EndpointResult};
+use endpoint::{with_get_cx, ApplyContext, Endpoint, EndpointResult};
 use error;
 use error::{err_msg, Error};
-use input::with_get_cx;
 
 /// Creates an endpoint which takes the instance of [`Payload`](input::body::Payload)
 /// from the context.
@@ -42,7 +41,7 @@ impl<'e> Endpoint<'e> for Raw {
     type Output = (Body,);
     type Future = RawFuture;
 
-    fn apply(&self, _: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, _: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         Ok(RawFuture { _priv: () })
     }
 }
@@ -83,7 +82,7 @@ impl<'a> Endpoint<'a> for ReceiveAll {
     type Output = (Bytes,);
     type Future = ReceiveAllFuture;
 
-    fn apply(&'a self, _: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, _: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         Ok(ReceiveAllFuture::new())
     }
 }
@@ -168,7 +167,7 @@ impl<'a> Endpoint<'a> for Text {
     type Output = (String,);
     type Future = parse::ParseFuture<String>;
 
-    fn apply(&'a self, _: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, _: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         Ok(parse::ParseFuture::new())
     }
 }
@@ -201,7 +200,7 @@ where
     type Future =
         ::futures::future::Map<parse::ParseFuture<parse::Json<T>>, fn((parse::Json<T>,)) -> (T,)>;
 
-    fn apply(&self, _: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, _: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         Ok(parse::ParseFuture::new().map((|(parse::Json(v),)| (v,)) as fn(_) -> _))
     }
 }
@@ -236,7 +235,7 @@ where
         fn((parse::UrlEncoded<T>,)) -> (T,),
     >;
 
-    fn apply(&self, _: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, _: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         Ok(parse::ParseFuture::new().map((|(parse::UrlEncoded(v),)| (v,)) as fn(_) -> _))
     }
 }
@@ -256,8 +255,8 @@ mod parse {
 
     use futures::{Future, Poll};
 
+    use endpoint::with_get_cx;
     use error::{bad_request, Error};
-    use input::with_get_cx;
 
     use super::ReceiveAllFuture;
 

--- a/src/endpoints/body.rs
+++ b/src/endpoints/body.rs
@@ -11,7 +11,7 @@ use http::StatusCode;
 use hyper::body::{Body, Payload};
 use serde::de::DeserializeOwned;
 
-use endpoint::{with_get_cx, ApplyContext, Endpoint, EndpointResult};
+use endpoint::{with_get_cx, ApplyContext, ApplyResult, Endpoint};
 use error;
 use error::{err_msg, Error};
 
@@ -41,7 +41,7 @@ impl<'e> Endpoint<'e> for Raw {
     type Output = (Body,);
     type Future = RawFuture;
 
-    fn apply(&self, _: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, _: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         Ok(RawFuture { _priv: () })
     }
 }
@@ -82,7 +82,7 @@ impl<'a> Endpoint<'a> for ReceiveAll {
     type Output = (Bytes,);
     type Future = ReceiveAllFuture;
 
-    fn apply(&'a self, _: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, _: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         Ok(ReceiveAllFuture::new())
     }
 }
@@ -167,7 +167,7 @@ impl<'a> Endpoint<'a> for Text {
     type Output = (String,);
     type Future = parse::ParseFuture<String>;
 
-    fn apply(&'a self, _: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, _: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         Ok(parse::ParseFuture::new())
     }
 }
@@ -200,7 +200,7 @@ where
     type Future =
         ::futures::future::Map<parse::ParseFuture<parse::Json<T>>, fn((parse::Json<T>,)) -> (T,)>;
 
-    fn apply(&self, _: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, _: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         Ok(parse::ParseFuture::new().map((|(parse::Json(v),)| (v,)) as fn(_) -> _))
     }
 }
@@ -235,7 +235,7 @@ where
         fn((parse::UrlEncoded<T>,)) -> (T,),
     >;
 
-    fn apply(&self, _: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, _: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         Ok(parse::ParseFuture::new().map((|(parse::UrlEncoded(v),)| (v,)) as fn(_) -> _))
     }
 }

--- a/src/endpoints/cookie.rs
+++ b/src/endpoints/cookie.rs
@@ -7,7 +7,7 @@ use cookie::Cookie;
 #[cfg(feature = "secure")]
 use cookie::Key;
 
-use endpoint::{ApplyContext, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, ApplyResult, Endpoint};
 use error::{bad_request, Error};
 use input::Input;
 
@@ -104,7 +104,7 @@ impl<'a> Endpoint<'a> for Required {
     type Output = (Cookie<'static>,);
     type Future = ::futures::future::FutureResult<Self::Output, Error>;
 
-    fn apply(&self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         let cookie = self
             .mode
             .extract_cookie(ecx.input(), &self.name)
@@ -179,7 +179,7 @@ impl<'a> Endpoint<'a> for Optional {
     type Output = (Option<Cookie<'static>>,);
     type Future = ::futures::future::FutureResult<Self::Output, Error>;
 
-    fn apply(&self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         Ok(::futures::future::result(
             self.mode
                 .extract_cookie(ecx.input(), &self.name)

--- a/src/endpoints/cookie.rs
+++ b/src/endpoints/cookie.rs
@@ -7,7 +7,7 @@ use cookie::Cookie;
 #[cfg(feature = "secure")]
 use cookie::Key;
 
-use endpoint::{Context, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, Endpoint, EndpointResult};
 use error::{bad_request, Error};
 use input::Input;
 
@@ -104,7 +104,7 @@ impl<'a> Endpoint<'a> for Required {
     type Output = (Cookie<'static>,);
     type Future = ::futures::future::FutureResult<Self::Output, Error>;
 
-    fn apply(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         let cookie = self
             .mode
             .extract_cookie(ecx.input(), &self.name)
@@ -179,7 +179,7 @@ impl<'a> Endpoint<'a> for Optional {
     type Output = (Option<Cookie<'static>>,);
     type Future = ::futures::future::FutureResult<Self::Output, Error>;
 
-    fn apply(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         Ok(::futures::future::result(
             self.mode
                 .extract_cookie(ecx.input(), &self.name)

--- a/src/endpoints/fs.rs
+++ b/src/endpoints/fs.rs
@@ -3,7 +3,7 @@
 use futures::{Future, Poll};
 use std::path::PathBuf;
 
-use endpoint::{Context, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, Endpoint, EndpointResult};
 use error::{bad_request, Error};
 use output::fs::OpenNamedFile;
 use output::NamedFile;
@@ -24,7 +24,7 @@ impl<'a> Endpoint<'a> for File {
     type Output = (NamedFile,);
     type Future = FileFuture;
 
-    fn apply(&self, _: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, _: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         Ok(FileFuture {
             state: State::Opening(NamedFile::open(self.path.clone())),
         })
@@ -47,7 +47,7 @@ impl<'a> Endpoint<'a> for Dir {
     type Output = (NamedFile,);
     type Future = FileFuture;
 
-    fn apply(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         let path = {
             match ecx.remaining_path().percent_decode() {
                 Ok(path) => Ok(PathBuf::from(path.into_owned())),

--- a/src/endpoints/fs.rs
+++ b/src/endpoints/fs.rs
@@ -3,7 +3,7 @@
 use futures::{Future, Poll};
 use std::path::PathBuf;
 
-use endpoint::{ApplyContext, Endpoint, EndpointResult};
+use endpoint::{ApplyContext, ApplyResult, Endpoint};
 use error::{bad_request, Error};
 use output::fs::OpenNamedFile;
 use output::NamedFile;
@@ -24,7 +24,7 @@ impl<'a> Endpoint<'a> for File {
     type Output = (NamedFile,);
     type Future = FileFuture;
 
-    fn apply(&self, _: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, _: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         Ok(FileFuture {
             state: State::Opening(NamedFile::open(self.path.clone())),
         })
@@ -47,7 +47,7 @@ impl<'a> Endpoint<'a> for Dir {
     type Output = (NamedFile,);
     type Future = FileFuture;
 
-    fn apply(&self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         let path = {
             match ecx.remaining_path().percent_decode() {
                 Ok(path) => Ok(PathBuf::from(path.into_owned())),

--- a/src/endpoints/header.rs
+++ b/src/endpoints/header.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::marker::PhantomData;
 
 use endpoint::with_get_cx;
-use endpoint::{ApplyContext, Endpoint, EndpointError, EndpointResult};
+use endpoint::{ApplyContext, ApplyError, ApplyResult, Endpoint};
 use error;
 use error::Error;
 use input::FromHeaderValue;
@@ -67,11 +67,11 @@ where
     type Output = (T,);
     type Future = ParseFuture<'e, T>;
 
-    fn apply(&'e self, cx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'e self, cx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         if cx.input().headers().contains_key(&self.name) {
             Ok(ParseFuture { endpoint: self })
         } else {
-            Err(EndpointError::custom(error::bad_request(format!(
+            Err(ApplyError::custom(error::bad_request(format!(
                 "missing header: `{}'",
                 self.name.as_str()
             ))))
@@ -152,7 +152,7 @@ where
     type Output = (Option<T>,);
     type Future = OptionalFuture<'e, T>;
 
-    fn apply(&'e self, _: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'e self, _: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         Ok(OptionalFuture { endpoint: self })
     }
 }
@@ -234,10 +234,10 @@ where
     type Output = ();
     type Future = ::futures::future::FutureResult<Self::Output, Error>;
 
-    fn apply(&'e self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'e self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         match ecx.input().headers().get(&self.name) {
             Some(value) if self.value == *value => Ok(::futures::future::result(Ok(()))),
-            _ => Err(EndpointError::not_matched()),
+            _ => Err(ApplyError::not_matched()),
         }
     }
 }
@@ -266,7 +266,7 @@ impl<'a> Endpoint<'a> for Raw {
     type Output = (Option<HeaderValue>,);
     type Future = ::futures::future::FutureResult<Self::Output, Error>;
 
-    fn apply(&'a self, cx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, cx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         let header = cx.input().headers().get(&self.name).cloned();
         Ok(::futures::future::result(Ok((header,))))
     }

--- a/src/endpoints/logging.rs
+++ b/src/endpoints/logging.rs
@@ -5,7 +5,7 @@ use http::StatusCode;
 use std::time::Instant;
 
 use endpoint::wrapper::Wrapper;
-use endpoint::{with_get_cx, ApplyContext, Endpoint, EndpointResult};
+use endpoint::{with_get_cx, ApplyContext, ApplyResult, Endpoint};
 use error::Error;
 use error::Never;
 use input::Input;
@@ -74,7 +74,7 @@ where
     type Output = (LoggedResponse<<E::Output as Output>::Body>,);
     type Future = WithLoggingFuture<'a, E::Future, F>;
 
-    fn apply(&'a self, cx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, cx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         let start = Instant::now();
         let future = self.endpoint.apply(cx)?;
         Ok(WithLoggingFuture {

--- a/src/endpoints/logging.rs
+++ b/src/endpoints/logging.rs
@@ -5,10 +5,10 @@ use http::StatusCode;
 use std::time::Instant;
 
 use endpoint::wrapper::Wrapper;
-use endpoint::{Context, Endpoint, EndpointResult};
+use endpoint::{with_get_cx, ApplyContext, Endpoint, EndpointResult};
 use error::Error;
 use error::Never;
-use input::{with_get_cx, Input};
+use input::Input;
 use output::body::ResBody;
 use output::{Output, OutputContext};
 
@@ -74,7 +74,7 @@ where
     type Output = (LoggedResponse<<E::Output as Output>::Body>,);
     type Future = WithLoggingFuture<'a, E::Future, F>;
 
-    fn apply(&'a self, cx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, cx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         let start = Instant::now();
         let future = self.endpoint.apply(cx)?;
         Ok(WithLoggingFuture {

--- a/src/endpoints/method.rs
+++ b/src/endpoints/method.rs
@@ -3,7 +3,7 @@
 use http::Method;
 
 use endpoint::syntax::verb::Verbs;
-use endpoint::{Context, Endpoint, EndpointError, EndpointResult, IntoEndpoint};
+use endpoint::{ApplyContext, Endpoint, EndpointError, EndpointResult, IntoEndpoint};
 
 #[allow(missing_docs)]
 #[derive(Debug, Clone)]
@@ -17,7 +17,7 @@ impl<'a, E: Endpoint<'a>> Endpoint<'a> for MatchMethod<E> {
     type Output = E::Output;
     type Future = E::Future;
 
-    fn apply(&'a self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         if *ecx.input().method() == self.method {
             self.endpoint.apply(ecx)
         } else {
@@ -65,7 +65,7 @@ macro_rules! define_method {
             type Output = E::Output;
             type Future = E::Future;
 
-            fn apply(&'e self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+            fn apply(&'e self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
                 if *ecx.input().method() == Method::$method {
                     self.endpoint.apply(ecx)
                 } else {

--- a/src/endpoints/method.rs
+++ b/src/endpoints/method.rs
@@ -3,7 +3,7 @@
 use http::Method;
 
 use endpoint::syntax::verb::Verbs;
-use endpoint::{ApplyContext, Endpoint, EndpointError, EndpointResult, IntoEndpoint};
+use endpoint::{ApplyContext, ApplyError, ApplyResult, Endpoint, IntoEndpoint};
 
 #[allow(missing_docs)]
 #[derive(Debug, Clone)]
@@ -17,11 +17,11 @@ impl<'a, E: Endpoint<'a>> Endpoint<'a> for MatchMethod<E> {
     type Output = E::Output;
     type Future = E::Future;
 
-    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         if *ecx.input().method() == self.method {
             self.endpoint.apply(ecx)
         } else {
-            Err(EndpointError::method_not_allowed(self.allowed))
+            Err(ApplyError::method_not_allowed(self.allowed))
         }
     }
 }
@@ -65,11 +65,11 @@ macro_rules! define_method {
             type Output = E::Output;
             type Future = E::Future;
 
-            fn apply(&'e self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+            fn apply(&'e self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
                 if *ecx.input().method() == Method::$method {
                     self.endpoint.apply(ecx)
                 } else {
-                    Err(EndpointError::method_not_allowed(Verbs::$method))
+                    Err(ApplyError::method_not_allowed(Verbs::$method))
                 }
             }
         }

--- a/src/endpoints/path.rs
+++ b/src/endpoints/path.rs
@@ -7,7 +7,7 @@ use failure::Fail;
 use http::StatusCode;
 use percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
 
-use endpoint::{Context, Endpoint, EndpointError, EndpointResult};
+use endpoint::{ApplyContext, Endpoint, EndpointError, EndpointResult};
 use error::{Error, HttpError};
 use input::FromEncodedStr;
 
@@ -37,7 +37,7 @@ impl<'a> Endpoint<'a> for MatchPath {
     type Output = ();
     type Future = ::futures::future::FutureResult<Self::Output, Error>;
 
-    fn apply(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         let s = ecx.next_segment().ok_or_else(EndpointError::not_matched)?;
         if s == self.encoded {
             Ok(::futures::future::result(Ok(())))
@@ -65,7 +65,7 @@ impl<'a> Endpoint<'a> for EndPath {
     type Output = ();
     type Future = ::futures::future::FutureResult<Self::Output, Error>;
 
-    fn apply(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         match ecx.next_segment() {
             None => Ok(::futures::future::result(Ok(()))),
             Some(..) => Err(EndpointError::not_matched()),
@@ -112,7 +112,7 @@ where
     type Output = (T,);
     type Future = ::futures::future::FutureResult<Self::Output, Error>;
 
-    fn apply(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         let s = ecx.next_segment().ok_or_else(EndpointError::not_matched)?;
         let result = T::from_encoded_str(s)
             .map(|x| (x,))
@@ -178,7 +178,7 @@ where
     type Output = (T,);
     type Future = ::futures::future::FutureResult<Self::Output, Error>;
 
-    fn apply(&self, ecx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         let result = T::from_encoded_str(ecx.remaining_path())
             .map(|x| (x,))
             .map_err(|cause| ParamError { cause }.into());

--- a/src/endpoints/path.rs
+++ b/src/endpoints/path.rs
@@ -7,7 +7,7 @@ use failure::Fail;
 use http::StatusCode;
 use percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
 
-use endpoint::{ApplyContext, Endpoint, EndpointError, EndpointResult};
+use endpoint::{ApplyContext, ApplyError, ApplyResult, Endpoint};
 use error::{Error, HttpError};
 use input::FromEncodedStr;
 
@@ -37,12 +37,12 @@ impl<'a> Endpoint<'a> for MatchPath {
     type Output = ();
     type Future = ::futures::future::FutureResult<Self::Output, Error>;
 
-    fn apply(&self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
-        let s = ecx.next_segment().ok_or_else(EndpointError::not_matched)?;
+    fn apply(&self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
+        let s = ecx.next_segment().ok_or_else(ApplyError::not_matched)?;
         if s == self.encoded {
             Ok(::futures::future::result(Ok(())))
         } else {
-            Err(EndpointError::not_matched())
+            Err(ApplyError::not_matched())
         }
     }
 }
@@ -65,10 +65,10 @@ impl<'a> Endpoint<'a> for EndPath {
     type Output = ();
     type Future = ::futures::future::FutureResult<Self::Output, Error>;
 
-    fn apply(&self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         match ecx.next_segment() {
             None => Ok(::futures::future::result(Ok(()))),
-            Some(..) => Err(EndpointError::not_matched()),
+            Some(..) => Err(ApplyError::not_matched()),
         }
     }
 }
@@ -112,8 +112,8 @@ where
     type Output = (T,);
     type Future = ::futures::future::FutureResult<Self::Output, Error>;
 
-    fn apply(&self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
-        let s = ecx.next_segment().ok_or_else(EndpointError::not_matched)?;
+    fn apply(&self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
+        let s = ecx.next_segment().ok_or_else(ApplyError::not_matched)?;
         let result = T::from_encoded_str(s)
             .map(|x| (x,))
             .map_err(|cause| ParamError { cause }.into());
@@ -178,7 +178,7 @@ where
     type Output = (T,);
     type Future = ::futures::future::FutureResult<Self::Output, Error>;
 
-    fn apply(&self, ecx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, ecx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         let result = T::from_encoded_str(ecx.remaining_path())
             .map(|x| (x,))
             .map_err(|cause| ParamError { cause }.into());

--- a/src/endpoints/query.rs
+++ b/src/endpoints/query.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::marker::PhantomData;
 
 use endpoint::with_get_cx;
-use endpoint::{ApplyContext, Endpoint, EndpointError, EndpointResult};
+use endpoint::{ApplyContext, ApplyError, ApplyResult, Endpoint};
 use error;
 use error::{bad_request, Error};
 
@@ -77,13 +77,13 @@ where
     type Output = (T,);
     type Future = RequiredFuture<T>;
 
-    fn apply(&self, cx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, cx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         if cx.input().uri().query().is_some() {
             Ok(RequiredFuture {
                 _marker: PhantomData,
             })
         } else {
-            Err(EndpointError::custom(error::bad_request("missing query")))
+            Err(ApplyError::custom(error::bad_request("missing query")))
         }
     }
 }
@@ -180,7 +180,7 @@ where
     type Output = (Option<T>,);
     type Future = OptionalFuture<T>;
 
-    fn apply(&self, _: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, _: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         Ok(OptionalFuture {
             _marker: PhantomData,
         })
@@ -225,7 +225,7 @@ impl<'a> Endpoint<'a> for Raw {
     type Output = (Option<String>,);
     type Future = RawFuture;
 
-    fn apply(&self, _: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, _: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         Ok(RawFuture { _priv: () })
     }
 }

--- a/src/endpoints/query.rs
+++ b/src/endpoints/query.rs
@@ -6,10 +6,10 @@ use serde_qs;
 use std::fmt;
 use std::marker::PhantomData;
 
-use endpoint::{Context, Endpoint, EndpointError, EndpointResult};
+use endpoint::with_get_cx;
+use endpoint::{ApplyContext, Endpoint, EndpointError, EndpointResult};
 use error;
 use error::{bad_request, Error};
-use input::with_get_cx;
 
 // ==== Required ====
 
@@ -77,7 +77,7 @@ where
     type Output = (T,);
     type Future = RequiredFuture<T>;
 
-    fn apply(&self, cx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, cx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         if cx.input().uri().query().is_some() {
             Ok(RequiredFuture {
                 _marker: PhantomData,
@@ -180,7 +180,7 @@ where
     type Output = (Option<T>,);
     type Future = OptionalFuture<T>;
 
-    fn apply(&self, _: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, _: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         Ok(OptionalFuture {
             _marker: PhantomData,
         })
@@ -225,7 +225,7 @@ impl<'a> Endpoint<'a> for Raw {
     type Output = (Option<String>,);
     type Future = RawFuture;
 
-    fn apply(&self, _: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&self, _: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         Ok(RawFuture { _priv: () })
     }
 }

--- a/src/input/global.rs
+++ b/src/input/global.rs
@@ -1,39 +1,12 @@
-use std::cell::Cell;
-use std::ptr::NonNull;
-
 use super::Input;
+use endpoint;
 
-thread_local!(static CX: Cell<Option<NonNull<Input>>> = Cell::new(None));
-
-struct SetOnDrop(Option<NonNull<Input>>);
-
-impl Drop for SetOnDrop {
-    fn drop(&mut self) {
-        CX.with(|cx| cx.set(self.0));
-    }
-}
-
-pub(crate) fn with_set_cx<R>(current: &mut Input, f: impl FnOnce() -> R) -> R {
-    CX.with(|cx| cx.set(NonNull::new(current)));
-    let _reset = SetOnDrop(None);
-    f()
-}
-
-/// Acquires a pinned reference to `Input` from the task context and executes the provided
-/// function using its value.
-///
-/// This function is usually used to access the value of `Input` within the `Future` returned
-/// by the `Endpoint`.
-///
-/// # Panics
-///
-/// A panic will occur if you call this function inside the provided closure `f`, since the
-/// reference to `Input` on the task context is invalidated while executing `f`.
+#[doc(hidden)]
+#[deprecated(
+    since = "0.12.0-alpha.9",
+    note = "use `endpoint::with_get_cx()` instead."
+)]
+#[inline(always)]
 pub fn with_get_cx<R>(f: impl FnOnce(&mut Input) -> R) -> R {
-    let prev = CX.with(|cx| cx.replace(None));
-    let _reset = SetOnDrop(prev);
-    match prev {
-        Some(mut ptr) => unsafe { f(ptr.as_mut()) },
-        None => panic!("reference to Input is not set at the task context."),
-    }
+    endpoint::with_get_cx(|cx| f(cx.input()))
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -9,8 +9,9 @@ pub use self::body::ReqBody;
 pub use self::encoded::{EncodedStr, FromEncodedStr};
 pub use self::header::FromHeaderValue;
 
+#[doc(hidden)]
+#[allow(deprecated)]
 pub use self::global::with_get_cx;
-pub(crate) use self::global::with_set_cx;
 
 // ====
 

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -28,7 +28,7 @@ mod sealed {
     use futures::Future;
 
     use common::Tuple;
-    use endpoint::{Context, Endpoint, EndpointResult};
+    use endpoint::{ApplyContext, Endpoint, EndpointResult};
     use error::Error;
     use output::Output;
 
@@ -36,7 +36,7 @@ mod sealed {
         type Output: Tuple + Output;
         type Future: Future<Item = Self::Output, Error = Error> + Send + 'a;
 
-        fn apply(&'a self, cx: &mut Context<'_>) -> EndpointResult<Self::Future>;
+        fn apply(&'a self, cx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future>;
 
         fn into_endpoint(self) -> IntoEndpoint<Self>
         where
@@ -55,7 +55,7 @@ mod sealed {
         type Output = E::Output;
         type Future = E::Future;
 
-        fn apply(&'a self, cx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+        fn apply(&'a self, cx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
             <Self as Endpoint<'a>>::apply(self, cx)
         }
     }
@@ -67,7 +67,7 @@ mod sealed {
         type Output = E::Output;
         type Future = E::Future;
 
-        fn apply(&'e self, cx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+        fn apply(&'e self, cx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
             self.0.apply(cx)
         }
     }

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -28,7 +28,7 @@ mod sealed {
     use futures::Future;
 
     use common::Tuple;
-    use endpoint::{ApplyContext, Endpoint, EndpointResult};
+    use endpoint::{ApplyContext, ApplyResult, Endpoint};
     use error::Error;
     use output::Output;
 
@@ -36,7 +36,7 @@ mod sealed {
         type Output: Tuple + Output;
         type Future: Future<Item = Self::Output, Error = Error> + Send + 'a;
 
-        fn apply(&'a self, cx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future>;
+        fn apply(&'a self, cx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future>;
 
         fn into_endpoint(self) -> IntoEndpoint<Self>
         where
@@ -55,7 +55,7 @@ mod sealed {
         type Output = E::Output;
         type Future = E::Future;
 
-        fn apply(&'a self, cx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+        fn apply(&'a self, cx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
             <Self as Endpoint<'a>>::apply(self, cx)
         }
     }
@@ -67,7 +67,7 @@ mod sealed {
         type Output = E::Output;
         type Future = E::Future;
 
-        fn apply(&'e self, cx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+        fn apply(&'e self, cx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
             self.0.apply(cx)
         }
     }

--- a/tests/endpoint/recover.rs
+++ b/tests/endpoint/recover.rs
@@ -1,5 +1,5 @@
 use finchers::endpoint::syntax;
-use finchers::endpoint::EndpointError;
+use finchers::endpoint::ApplyError;
 use finchers::local;
 use finchers::prelude::*;
 use futures::future;
@@ -17,7 +17,7 @@ fn test_recover() {
     let recovered = endpoint
         .wrap(endpoint::wrapper::or_reject())
         .wrap(endpoint::wrapper::recover(|err| {
-            if err.is::<EndpointError>() {
+            if err.is::<ApplyError>() {
                 future::ok(
                     Response::builder()
                         .status(err.status_code())

--- a/tests/endpoint/syntax.rs
+++ b/tests/endpoint/syntax.rs
@@ -1,5 +1,5 @@
 use finchers::endpoint::syntax;
-use finchers::endpoint::EndpointError;
+use finchers::endpoint::ApplyError;
 use finchers::local;
 use finchers::prelude::*;
 
@@ -47,7 +47,7 @@ fn test_extract_integer() {
     assert_matches!(local::get("/42").apply(&endpoint), Ok((42i32,)));
     assert_matches!(
         local::get("/foo").apply(&endpoint),
-        Err(ref e) if e.is::<EndpointError>() && e.status_code() == StatusCode::BAD_REQUEST
+        Err(ref e) if e.is::<ApplyError>() && e.status_code() == StatusCode::BAD_REQUEST
     );
 }
 

--- a/tests/endpoint/wrap.rs
+++ b/tests/endpoint/wrap.rs
@@ -1,5 +1,5 @@
 use finchers;
-use finchers::endpoint::{Context, Endpoint, EndpointResult, Wrapper};
+use finchers::endpoint::{ApplyContext, Endpoint, EndpointResult, Wrapper};
 use finchers::local;
 
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -31,7 +31,7 @@ impl<'a, E: Endpoint<'a>> Endpoint<'a> for Wrapped<E> {
     type Output = E::Output;
     type Future = E::Future;
 
-    fn apply(&'a self, cx: &mut Context<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, cx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
         self.counter.fetch_add(1, Ordering::SeqCst);
         self.endpoint.apply(cx)
     }

--- a/tests/endpoint/wrap.rs
+++ b/tests/endpoint/wrap.rs
@@ -1,5 +1,5 @@
 use finchers;
-use finchers::endpoint::{ApplyContext, Endpoint, EndpointResult, Wrapper};
+use finchers::endpoint::{ApplyContext, ApplyResult, Endpoint, Wrapper};
 use finchers::local;
 
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -31,7 +31,7 @@ impl<'a, E: Endpoint<'a>> Endpoint<'a> for Wrapped<E> {
     type Output = E::Output;
     type Future = E::Future;
 
-    fn apply(&'a self, cx: &mut ApplyContext<'_>) -> EndpointResult<Self::Future> {
+    fn apply(&'a self, cx: &mut ApplyContext<'_>) -> ApplyResult<Self::Future> {
         self.counter.fetch_add(1, Ordering::SeqCst);
         self.endpoint.apply(cx)
     }

--- a/tests/endpoints/query.rs
+++ b/tests/endpoints/query.rs
@@ -1,5 +1,5 @@
+use finchers::endpoint::ApplyError;
 use finchers::endpoint::Endpoint;
-use finchers::endpoint::EndpointError;
 use finchers::endpoints::query;
 use finchers::local;
 
@@ -35,7 +35,7 @@ fn test_query_parse() {
     assert_matches!(
         local::get("/")
             .apply(&endpoint),
-        Err(ref err) if err.is::<EndpointError>() && err.status_code().as_u16() == 400
+        Err(ref err) if err.is::<ApplyError>() && err.status_code().as_u16() == 400
     );
 }
 


### PR DESCRIPTION
* rename `endpoint::Context` to `endpoint::ApplyContext`
* make `input::with_get_cx` deprecated
* add a new context type `TaskContext` for provides the way
  to access contextual data during polling the futures returned
  from `Endpoint`s.
* rename `EndpointError`/`EndpointResult` to `ApplyError`/`ApplyResult`
