### PR TITLE
Remove unneeded feature flags

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,4 +29,6 @@ build: false
 
 test_script:
   - cargo clean
-  - cargo test --features strict
+  - cargo test
+  - cargo test --all-features
+  - cargo test --no-default-features

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,39 +29,36 @@ matrix:
         - cargo install cargo-update || true
         - cargo install cargo-kcov || true
         - cargo install-update -a
-        - export CARGO_INCREMENTAL=0
       script:
         - cargo fmt -- --check
         - cargo update
-        - cargo test --features strict
-        - cargo test --features strict --no-default-features
-        - if [[ "${TRAVIS_PULL_REQUEST_BRANCH:-}" = release-* ]]; then cargo package; fi
+        - cargo test
+        - cargo test --all-features
+        - cargo test --no-default-features
+        - if [[ "${TRAVIS_PULL_REQUEST_BRANCH:-}" = release-* ]]; then cargo publish --dry-run; fi
       after_success:
         - cargo kcov --print-install-kcov-sh | sh
         - cargo kcov -v --coveralls
 
     - rust: beta
-      before_script:
-        - export CARGO_INCREMENTAL=0
-      script:
-        - cargo update
-        - cargo test --features strict
-        - cargo test --features strict --no-default-features
-        - (cd testcrates/test_edition_2018; cargo test)
-
-    - rust: nightly
-      before_script:
-        - export CARGO_INCREMENTAL=0
       script:
         - cargo update
         - cargo test
+        - cargo test --all-features
+        - cargo test --no-default-features
+        - (cd testcrates/test_edition_2018; cargo test)
+
+    - rust: nightly
+      script:
+        - cargo update
+        - cargo test
+        - cargo test --all-features
         - cargo test --no-default-features
 
     - rust: stable
       env: LINT
       before_script:
         - rustup component add clippy-preview
-        - export CARGO_INCREMENTAL=0
       script:
         - cargo clippy
 
@@ -70,7 +67,7 @@ matrix:
       script:
         - rm -rf target/doc
         - cargo update
-        - cargo doc --no-deps
+        - cargo doc --no-deps --all-features
         - rm -f target/doc/.lock
         - echo '<meta http-equiv="refresh" content="0;URL=finchers/index.html">' > target/doc/index.html
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,13 +57,13 @@ matrix:
         - cargo test
         - cargo test --no-default-features
 
-    - rust: nightly
+    - rust: stable
       env: LINT
       before_script:
         - rustup component add clippy-preview
         - export CARGO_INCREMENTAL=0
       script:
-        - cargo clippy --features lint
+        - cargo clippy
 
     - rust: stable
       env: DEPLOY_API_DOC

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
 
   include:
     - rust: stable
+      env: RUSTFLAGS="--cfg finchers_deny_warnings"
       sudo: required
       addons:
         apt:
@@ -37,10 +38,12 @@ matrix:
         - cargo test --no-default-features
         - if [[ "${TRAVIS_PULL_REQUEST_BRANCH:-}" = release-* ]]; then cargo publish --dry-run; fi
       after_success:
+        - export RUSTFLAGS=""
         - cargo kcov --print-install-kcov-sh | sh
         - cargo kcov -v --coveralls
 
     - rust: beta
+      env: RUSTFLAGS="--cfg finchers_deny_warnings"
       script:
         - cargo update
         - cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,8 @@ include = [
 ]
 
 [package.metadata.docs.rs]
-features = [
-  # FIXME: remove it as soon as the rustc version used in docs.rs is updated
-  "extern-prelude",
-]
+# FIXME: remove it as soon as the rustc version used in docs.rs is updated
+rustc-args = ["--cfg", "finchers_inject_extern_prelude"]
 
 [badges]
 travis-ci = { repository = "finchers-rs/finchers" }
@@ -56,6 +54,3 @@ default = ["secure"]
 strict = []
 lint = ["strict"]
 secure = ["cookie/secure"]
-
-# FIXME: remove it as soon as the rustc version used in docs.rs is updated
-extern-prelude = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,5 +51,4 @@ matches = "0.1.8"
 
 [features]
 default = ["secure"]
-strict = []
 secure = ["cookie/secure"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,5 +52,4 @@ matches = "0.1.8"
 [features]
 default = ["secure"]
 strict = []
-lint = ["strict"]
 secure = ["cookie/secure"]

--- a/src/endpoint/and.rs
+++ b/src/endpoint/and.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "lint", allow(clippy::type_complexity))]
+#![cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
 
 use std::fmt;
 

--- a/src/endpoint/context.rs
+++ b/src/endpoint/context.rs
@@ -153,7 +153,7 @@ impl Drop for SetOnDrop {
     }
 }
 
-#[cfg_attr(feature = "lint", allow(clippy::cast_ptr_alignment))]
+#[cfg_attr(feature = "cargo-clippy", allow(cast_ptr_alignment))]
 pub(crate) fn with_set_cx<R>(current: &mut TaskContext<'_>, f: impl FnOnce() -> R) -> R {
     CX.with(|cx| {
         cx.set(Some(unsafe {

--- a/src/endpoints/body.rs
+++ b/src/endpoints/body.rs
@@ -196,7 +196,7 @@ where
     T: DeserializeOwned + 'static,
 {
     type Output = (T,);
-    #[cfg_attr(feature = "lint", allow(clippy::type_complexity))]
+    #[cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
     type Future =
         ::futures::future::Map<parse::ParseFuture<parse::Json<T>>, fn((parse::Json<T>,)) -> (T,)>;
 
@@ -229,7 +229,7 @@ where
     T: DeserializeOwned + 'static,
 {
     type Output = (T,);
-    #[cfg_attr(feature = "lint", allow(clippy::type_complexity))]
+    #[cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
     type Future = ::futures::future::Map<
         parse::ParseFuture<parse::UrlEncoded<T>>,
         fn((parse::UrlEncoded<T>,)) -> (T,),

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -24,7 +24,7 @@ use error::{bad_request, Error};
 #[derive(Debug)]
 pub struct Input {
     request: Request<ReqBody>,
-    #[cfg_attr(feature = "lint", allow(clippy::option_option))]
+    #[cfg_attr(feature = "cargo-clippy", allow(option_option))]
     media_type: Option<Option<Mime>>,
     cookie_jar: Option<CookieJar>,
     response_headers: Option<HeaderMap>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,8 @@
 )]
 // FIXME: re-enable the following lint after shipping rust-1.31 out
 // #![warn(rust_2018_compatibility)]
-#![cfg_attr(feature = "strict", deny(warnings))]
-#![cfg_attr(feature = "strict", doc(test(attr(deny(warnings)))))]
+#![cfg_attr(test, deny(warnings))]
+#![cfg_attr(test, doc(test(attr(deny(warnings)))))]
 
 #[macro_use]
 extern crate bitflags;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(feature = "lint", feature(tool_lints))]
 // FIXME: remove this feature gate as soon as the rustc version used in docs.rs is updated
 #![cfg_attr(finchers_inject_extern_prelude, feature(extern_prelude))]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(feature = "lint", feature(tool_lints))]
 // FIXME: remove this feature gate as soon as the rustc version used in docs.rs is updated
-#![cfg_attr(feature = "extern-prelude", feature(extern_prelude))]
+#![cfg_attr(finchers_inject_extern_prelude, feature(extern_prelude))]
 
 //! A combinator library for building asynchronous HTTP services.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,8 @@
 )]
 // FIXME: re-enable the following lint after shipping rust-1.31 out
 // #![warn(rust_2018_compatibility)]
-#![cfg_attr(test, deny(warnings))]
-#![cfg_attr(test, doc(test(attr(deny(warnings)))))]
+#![cfg_attr(finchers_deny_warnings, deny(warnings))]
+#![cfg_attr(finchers_deny_warnings, doc(test(attr(deny(warnings)))))]
 
 #[macro_use]
 extern crate bitflags;

--- a/testcrates/test_edition_2018/src/lib.rs
+++ b/testcrates/test_edition_2018/src/lib.rs
@@ -1,3 +1,6 @@
+#![cfg_attr(finchers_deny_warnings, deny(warnings))]
+#![cfg_attr(finchers_deny_warnings, doc(test(attr(deny(warnings)))))]
+
 #[cfg(test)]
 mod tests {
     use finchers::path;


### PR DESCRIPTION
It removes some features flags for setting the lint capabilities.
It is intended to allow the crate user uses `all-features` option.

Compatibility Notes:
Strictly, removing the feature flags is breaking change and hence it is need to bump the major version of crate up to the next iteration. However, since these flags are not documented, removing them should not affect the normal crate user.