### PR TITLE
Release 0.12.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,5 +50,5 @@ url = "1.7.1"
 matches = "0.1.8"
 
 [features]
-default = ["secure"]
+default = []
 secure = ["cookie/secure"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "finchers"
-version = "0.12.0" # don't forget to update html_root_url in lib.rs
+version = "0.12.1" # don't forget to update html_root_url in lib.rs
 description = "A combinator library for builidng asynchronous HTTP services"
 authors = ["Yusuke Sasaki <yusuke.sasaki.nuem@gmail.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 homepage = "https://finchers-rs.github.io"
-documentation = "https://finchers-rs.github.io/docs"
 repository = "https://github.com/finchers-rs/finchers.git"
 keywords = ["finchers", "web", "framework", "server"]
 categories = ["web-programming::http-server"]
@@ -16,6 +15,11 @@ include = [
   "build.rs",
   "src/**/*",
   "tests/**/*",
+  "examples/**/*",
+  "benches/**/*",
+  "LICENSE-MIT",
+  "LICENSE-APACHE",
+  "README.md"
 ]
 
 [package.metadata.docs.rs]
@@ -23,8 +27,6 @@ include = [
 rustc-args = ["--cfg", "finchers_inject_extern_prelude"]
 
 [badges]
-travis-ci = { repository = "finchers-rs/finchers" }
-coveralls = { repository = "finchers-rs/finchers" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # `finchers`
 
-[![crates.io][crates-io-badge]][crates-io]
-[![API documentation][api-docs-badge]][api-docs]
+[![Crates.io][crates-io-badge]][crates-io]
+[![Crates.io (Downloads)][downloads-badge]][crates-io]
+[![Docs.rs][docs-rs-badge]][docs-rs]
 [![dependency status][dependencies-badge]][dependencies]
 [![Gitter][gitter-badge]][gitter]
 
@@ -56,6 +57,7 @@ at your option.
 <!-- links -->
 
 [crates-io]: https://crates.io/crates/finchers
+[docs-rs]: https://docs.rs/finchers
 [api-docs]: https://finchers-rs.github.io/docs
 [examples]: https://github.com/finchers-rs/examples
 [user-guide]: https://finchers-rs.github.io/finchers/guide/index.html
@@ -66,7 +68,8 @@ at your option.
 [dependencies]: https://deps.rs/repo/github/finchers-rs/finchers
 
 [crates-io-badge]: https://img.shields.io/crates/v/finchers.svg
-[api-docs-badge]: https://img.shields.io/badge/api-docs-blue.svg
+[downloads-badge]: https://img.shields.io/crates/d/finchers.svg
+[docs-rs-badge]: https://docs.rs/finchers/badge.svg
 [gitter-badge]: https://badges.gitter.im/finchers-rs/finchers.svg
 [travis-badge]: https://travis-ci.org/finchers-rs/finchers.svg?branch=master
 [appveyor-badge]: https://ci.appveyor.com/api/projects/status/76smoc919fni4n6l/branch/master?svg=true

--- a/changelog/0.12.x.md
+++ b/changelog/0.12.x.md
@@ -1,4 +1,11 @@
+<a name="0.12.1"></a>
+## 0.12.1 (2018-10-02)
+
+* add flag to `output::body::Empty` to set the end of stream ([#340](https://github.com/finchers-rs/finchers/pull/340))
+* remove unneeded feature flags ([#342](https://github.com/finchers-rs/finchers/pull/342))
+* disable the feature flag 'secure' by default
+
 <a name="0.12.0"></a>
-# 0.12.0 (2018-09-30)
+# 0.12.0 (2018-09-30) (yanked)
 
 The first release on this iteration.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,10 +35,7 @@
 //! }
 //! ```
 
-// master
-//#![doc(html_root_url = "https://finchers-rs.github.io/finchers/")]
-// released
-#![doc(html_root_url = "https://finchers-rs.github.io/docs/finchers/v0.12.0")]
+#![doc(html_root_url = "https://docs.rs/finchers/0.12.1")]
 #![warn(
     missing_docs,
     missing_debug_implementations,


### PR DESCRIPTION
Note:
* `0.12.0` will be yanked because it contains wrong conditions in `Cargo.toml` (unneeded feature flags and enable 'secure' by default)