### PR TITLE
bump version to 0.12.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finchers"
-version = "0.12.1" # don't forget to update html_root_url in lib.rs
+version = "0.12.2" # don't forget to update html_root_url in lib.rs
 description = "A combinator library for builidng asynchronous HTTP services"
 authors = ["Yusuke Sasaki <yusuke.sasaki.nuem@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/changelog/0.12.x.md
+++ b/changelog/0.12.x.md
@@ -1,5 +1,9 @@
+<a name="0.12.2"></a>
+## 0.12.2 (2018-10-02)
+* fix the value of [package.metadata.docs.rs]
+
 <a name="0.12.1"></a>
-## 0.12.1 (2018-10-02)
+## 0.12.1 (2018-10-02) (yanked)
 
 * add flag to `output::body::Empty` to set the end of stream ([#340](https://github.com/finchers-rs/finchers/pull/340))
 * remove unneeded feature flags ([#342](https://github.com/finchers-rs/finchers/pull/342))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //! }
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/finchers/0.12.1")]
+#![doc(html_root_url = "https://docs.rs/finchers/0.12.2")]
 #![warn(
     missing_docs,
     missing_debug_implementations,


### PR DESCRIPTION
The release modifies only the value of Cargo.toml's metadata for running rustdoc correctly.