### PR TITLE
finalize the protocol upgrade API

### DIFF
--- a/src/input/body.rs
+++ b/src/input/body.rs
@@ -1,14 +1,45 @@
+use std::error::Error as StdError;
+use std::fmt;
+use std::io;
+use std::mem;
+
+use bytes::Bytes;
+use futures::Poll;
+use http::header::HeaderMap;
 use hyper::body::Body;
+
+#[cfg(feature = "rt")]
+use futures::Future;
+
+#[cfg(feature = "rt")]
+type Task = Box<dyn Future<Item = (), Error = ()> + Send + 'static>;
+
+enum ReqBodyState {
+    Unused(Body),
+    Gone,
+    #[cfg(feature = "rt")]
+    Upgraded(Task),
+}
+
+impl fmt::Debug for ReqBodyState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ReqBodyState::Unused(ref bd) => f.debug_tuple("Unused").field(bd).finish(),
+            ReqBodyState::Gone => f.debug_tuple("Gone").finish(),
+            #[cfg(feature = "rt")]
+            ReqBodyState::Upgraded(..) => f.debug_tuple("Upgraded").finish(),
+        }
+    }
+}
 
 /// A type holding the instance of request body.
 #[derive(Debug)]
 pub struct ReqBody {
-    inner: Option<Body>,
-    is_upgraded: bool,
+    state: ReqBodyState,
 }
 
 impl ReqBody {
-    /// Create an instance of `RequestBody` from `hyper::Body`.
+    #[doc(hidden)]
     #[deprecated(
         since = "0.12.3",
         note = "This method will be removed in the future version."
@@ -20,76 +51,195 @@ impl ReqBody {
 
     pub(crate) fn new(body: Body) -> ReqBody {
         ReqBody {
-            inner: Some(body),
-            is_upgraded: false,
+            state: ReqBodyState::Unused(body),
         }
     }
 
-    #[allow(missing_docs)]
+    #[inline]
+    #[doc(hidden)]
+    #[deprecated(since = "0.12.3", note = "use `ReqBody::take()` instead.")]
     pub fn payload(&mut self) -> Option<Body> {
-        self.inner.take()
+        self.take().map(|Payload(body)| body)
     }
 
-    #[allow(missing_docs)]
+    /// Takes the instance of raw request body from the current context.
+    ///
+    /// It returns a `None` if the instance has already taken or the request
+    /// has already upgraded to another protocol.
+    pub fn take(&mut self) -> Option<Payload> {
+        match mem::replace(&mut self.state, ReqBodyState::Gone) {
+            ReqBodyState::Unused(body) => Some(Payload(body)),
+            ReqBodyState::Gone => None,
+            #[cfg(feature = "rt")]
+            ReqBodyState::Upgraded(task) => {
+                self.state = ReqBodyState::Upgraded(task);
+                None
+            }
+        }
+    }
+    /// Returns whether the instance of `Payload` is available or not.
+    ///
+    /// It returns `false` if the request body has already taken or upgraded to another protocol.
+    pub fn is_available(&self) -> bool {
+        match self.state {
+            ReqBodyState::Unused(..) => false,
+            _ => true,
+        }
+    }
+
+    /// Returns whether the protocol has already upgraded to another protocol.
+    #[cfg(feature = "rt")]
+    pub fn is_upgraded(&self) -> bool {
+        match self.state {
+            ReqBodyState::Upgraded(..) => true,
+            _ => false,
+        }
+    }
+
+    #[doc(hidden)]
+    #[deprecated(
+        since = "0.12.3",
+        note = "use `!body.is_available()` instead"
+    )]
     pub fn is_gone(&self) -> bool {
-        self.inner.is_none()
+        !self.is_available()
+    }
+}
+
+/// An asynchronous stream of bytes representing the raw request body.
+///
+/// This type is currently a thin wrapper of `hyper::Body`.
+#[derive(Debug)]
+pub struct Payload(Body);
+
+impl Payload {
+    pub(crate) fn into_inner(self) -> Body {
+        self.0
+    }
+}
+
+impl ::hyper::body::Payload for Payload {
+    type Data = io::Cursor<Bytes>;
+    type Error = Box<dyn StdError + Send + Sync + 'static>;
+
+    #[inline]
+    fn poll_data(&mut self) -> Poll<Option<Self::Data>, Self::Error> {
+        self.0
+            .poll_data()
+            .map(|x| x.map(|chunk_opt| chunk_opt.map(|chunk| io::Cursor::new(chunk.into_bytes()))))
+            .map_err(Into::into)
+    }
+
+    #[inline]
+    fn poll_trailers(&mut self) -> Poll<Option<HeaderMap>, Self::Error> {
+        self.0.poll_trailers().map_err(Into::into)
+    }
+
+    #[inline]
+    fn is_end_stream(&self) -> bool {
+        self.0.is_end_stream()
+    }
+
+    #[inline]
+    fn content_length(&self) -> Option<u64> {
+        self.0.content_length()
+    }
+}
+
+impl ::futures::Stream for Payload {
+    type Item = Bytes;
+    type Error = Box<dyn StdError + Send + Sync + 'static>;
+
+    #[inline]
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        self.0
+            .poll()
+            .map(|x| x.map(|chunk_opt| chunk_opt.map(Into::into)))
+            .map_err(Into::into)
     }
 }
 
 #[cfg(feature = "rt")]
 mod rt {
-    use super::ReqBody;
+    use super::{ReqBody, ReqBodyState, Task};
 
     use futures::{Future, IntoFuture};
     use hyper::body::Payload;
     use hyper::upgrade::Upgraded;
-    use tokio::executor::Executor;
+    use std::mem;
 
-    use rt::DefaultExecutor;
-
-    /// The implmentation for supporting HTTP/1.1 protocol upgrade.
-    ///
-    /// These methods is currently unstable and disabled by default.
-    /// They are available only when the feature `rt` is set.
     impl ReqBody {
-        #[allow(missing_docs)]
-        #[inline]
-        pub fn upgrade<F, R, Exec>(&mut self, f: F)
+        pub(crate) fn upgrade<F, R>(&mut self, f: F)
         where
             F: FnOnce(Upgraded) -> R + Send + 'static,
             R: IntoFuture<Item = (), Error = ()>,
             R::Future: Send + 'static,
-            Exec: Executor,
         {
-            self.upgrade_with_executor(f, &mut DefaultExecutor::current())
-        }
-
-        #[allow(missing_docs)]
-        pub fn upgrade_with_executor<F, R, Exec>(&mut self, f: F, exec: &mut Exec)
-        where
-            F: FnOnce(Upgraded) -> R + Send + 'static,
-            R: IntoFuture<Item = (), Error = ()>,
-            R::Future: Send + 'static,
-            Exec: Executor,
-        {
-            if let Some(body) = self.inner.take() {
-                self.is_upgraded = true;
-                let future = body
-                    .on_upgrade()
-                    .map_err(|e| error!("during upgrading the protocol: {}", e))
-                    .and_then(|upgraded| f(upgraded).into_future());
-                exec.spawn(Box::new(future))
-                    .expect("failed to spawn the upgraded task");
+            match mem::replace(&mut self.state, ReqBodyState::Gone) {
+                ReqBodyState::Unused(body) => {
+                    self.state = ReqBodyState::Upgraded(Box::new(
+                        body.on_upgrade()
+                            .map_err(|e| error!("during upgrading the protocol: {}", e))
+                            .and_then(|upgraded| f(upgraded).into_future()),
+                    ));
+                }
+                ReqBodyState::Gone => {}
+                ReqBodyState::Upgraded(task) => {
+                    self.state = ReqBodyState::Upgraded(task);
+                }
             }
         }
 
-        #[allow(missing_docs)]
-        pub fn is_upgraded(&self) -> bool {
-            self.is_gone() && self.is_upgraded
+        pub(crate) fn into_upgraded(self) -> Option<Task> {
+            match self.state {
+                ReqBodyState::Upgraded(task) => Some(task),
+                _ => None,
+            }
         }
 
         pub(crate) fn content_length(&self) -> Option<u64> {
-            self.inner.as_ref()?.content_length()
+            match self.state {
+                ReqBodyState::Unused(ref body) => body.content_length(),
+                _ => None,
+            }
         }
     }
+}
+
+#[cfg(all(feature = "rt", feature = "tower-web"))]
+mod payload_buf_stream {
+    use super::Payload;
+
+    use bytes::Bytes;
+    use futures::Poll;
+    use hyper::body::Payload as _HyperPayload;
+    use std::error::Error as StdError;
+    use std::io;
+
+    use tower_web::util::buf_stream::size_hint::Builder;
+    use tower_web::util::buf_stream::{BufStream, SizeHint};
+
+    impl BufStream for Payload {
+        type Item = io::Cursor<Bytes>;
+        type Error = Box<dyn StdError + Send + Sync + 'static>;
+
+        #[inline]
+        fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+            self.poll_data()
+        }
+
+        fn size_hint(&self) -> SizeHint {
+            let mut builder = Builder::new();
+            if let Some(length) = self.content_length() {
+                if length < usize::max_value() as u64 {
+                    let length = length as usize;
+                    builder.lower(length).upper(length);
+                } else {
+                    builder.lower(usize::max_value());
+                }
+            }
+            builder.build()
+        }
+    }
+
 }

--- a/tests/rt/endpoints/mod.rs
+++ b/tests/rt/endpoints/mod.rs
@@ -1,3 +1,4 @@
 mod body;
 mod header;
 mod query;
+mod upgrade;

--- a/tests/rt/endpoints/upgrade.rs
+++ b/tests/rt/endpoints/upgrade.rs
@@ -1,0 +1,25 @@
+use finchers::endpoints::upgrade::Builder;
+use finchers::prelude::*;
+use finchers::rt::test;
+
+#[test]
+fn test_upgrade() {
+    let mut runner = test::runner({
+        endpoints::upgrade::builder().map(|builder: Builder| {
+            builder
+                .header("sec-websocket-accept", "xxxx")
+                .finish(|upgraded| {
+                    drop(upgraded);
+                    Ok(())
+                })
+        })
+    });
+
+    let response = runner.apply_all("/");
+    assert!(response.is_upgraded());
+    assert_eq!(response.status.as_u16(), 101);
+    assert_matches!(
+        response.headers.get("sec-websocket-accept"),
+        Some(h) if h == "xxxx"
+    );
+}


### PR DESCRIPTION
This PR also include some changes around `ReqBody` because the support for protocol upgrade is highly depended on its type.