### PR TITLE
reform Cookie endpoints

### DIFF
--- a/.cargo-husky/hooks/pre-push
+++ b/.cargo-husky/hooks/pre-push
@@ -14,7 +14,7 @@ BRANCH="$(git symbolic-ref --short HEAD)"
 }
 
 if rake --version >/dev/null 2>&1; then
-    rake FINCHERS_DENY_WARNINGS=1
+    (set -x; rake FINCHERS_DENY_WARNINGS=1)
 else
     echo "[warn] 'rake' is not installed."
 fi

--- a/src/input/cookie.rs
+++ b/src/input/cookie.rs
@@ -1,0 +1,115 @@
+use http::header::HeaderMap;
+use http::header::COOKIE;
+use std::cell::UnsafeCell;
+use std::marker::PhantomData;
+
+use cookie::Cookie;
+pub(super) use cookie::CookieJar;
+#[cfg(feature = "secure")]
+use cookie::Key;
+
+use endpoint::with_get_cx;
+use error;
+use error::Error;
+
+/// A proxy object for tracking Cookie values in the current context.
+#[derive(Debug)]
+pub struct Cookies {
+    _marker: PhantomData<UnsafeCell<()>>,
+}
+
+impl Cookies {
+    fn with_get_jar<R>(f: impl FnOnce(&mut CookieJar) -> R) -> R {
+        with_get_cx(|cx| {
+            let jar = cx
+                .input()
+                .cookie_manager
+                .jar()
+                .expect("should be available");
+            f(jar)
+        })
+    }
+
+    /// Return a Cookie with the specified name from the jar in the current context.
+    pub fn get(&self, name: &str) -> Option<Cookie<'static>> {
+        Cookies::with_get_jar(|jar| jar.get(name).cloned())
+    }
+
+    /// Adds a Cookie entry to the jar in the current context.
+    pub fn add(&mut self, cookie: Cookie<'static>) {
+        Cookies::with_get_jar(|jar| jar.add(cookie))
+    }
+
+    /// Removes a Cookie entry from the jar in the current context.
+    pub fn remove(&mut self, cookie: Cookie<'static>) {
+        Cookies::with_get_jar(|jar| jar.remove(cookie))
+    }
+
+    /// Removes *completely* a Cookie entry from the jar in the current context.
+    pub fn force_remove(&mut self, cookie: Cookie<'static>) {
+        Cookies::with_get_jar(|jar| jar.force_remove(cookie))
+    }
+}
+
+#[allow(missing_docs)]
+#[cfg(feature = "secure")]
+impl Cookies {
+    pub fn get_signed(&self, key: &Key, name: &str) -> Option<Cookie<'static>> {
+        Cookies::with_get_jar(|jar| jar.signed(key).get(name))
+    }
+
+    pub fn get_private(&self, key: &Key, name: &str) -> Option<Cookie<'static>> {
+        Cookies::with_get_jar(|jar| jar.private(key).get(name))
+    }
+
+    pub fn add_signed(&mut self, key: &Key, cookie: Cookie<'static>) {
+        Cookies::with_get_jar(|jar| jar.signed(key).add(cookie))
+    }
+
+    pub fn add_private(&mut self, key: &Key, cookie: Cookie<'static>) {
+        Cookies::with_get_jar(|jar| jar.private(key).add(cookie))
+    }
+
+    pub fn remove_signed(&mut self, key: &Key, cookie: Cookie<'static>) {
+        Cookies::with_get_jar(|jar| jar.signed(key).remove(cookie))
+    }
+
+    pub fn remove_private(&mut self, key: &Key, cookie: Cookie<'static>) {
+        Cookies::with_get_jar(|jar| jar.private(key).remove(cookie))
+    }
+}
+
+#[derive(Debug, Default)]
+pub(super) struct CookieManager {
+    jar: Option<CookieJar>,
+}
+
+impl CookieManager {
+    pub(super) fn ensure_initialized(&mut self, headers: &HeaderMap) -> Result<Cookies, Error> {
+        if self.jar.is_none() {
+            let mut cookie_jar = CookieJar::new();
+            for cookie in headers.get_all(COOKIE) {
+                let cookie_str = cookie.to_str().map_err(error::bad_request)?;
+                for s in cookie_str.split(';').map(|s| s.trim()) {
+                    let cookie = Cookie::parse_encoded(s)
+                        .map_err(error::bad_request)?
+                        .into_owned();
+                    cookie_jar.add_original(cookie);
+                }
+            }
+            self.jar.get_or_insert(cookie_jar);
+        }
+
+        Ok(Cookies {
+            _marker: PhantomData,
+        })
+    }
+
+    pub(super) fn jar(&mut self) -> Option<&mut CookieJar> {
+        self.jar.as_mut()
+    }
+
+    pub(super) fn into_inner(self) -> Option<CookieJar> {
+        self.jar
+    }
+}

--- a/tests/endpoints/cookie.rs
+++ b/tests/endpoints/cookie.rs
@@ -1,0 +1,66 @@
+use cookie::Cookie;
+use finchers::input::Cookies;
+use finchers::prelude::*;
+use finchers::test;
+use http::Request;
+
+#[test]
+fn test_cookies_get() {
+    let mut runner = test::runner({
+        endpoints::cookie::cookies().map(|cookies: Cookies| cookies.get("session-id"))
+    });
+
+    assert_matches!(
+        runner.apply(Request::get("/")
+            .header("cookie", "session-id=xxxx")),
+        Ok(Some(ref cookie))
+            if cookie.name() == "session-id" &&
+               cookie.value() == "xxxx"
+    );
+}
+
+#[test]
+fn test_cookies_add() {
+    let mut runner = test::runner({
+        endpoints::cookie::cookies().map(|mut cookies: Cookies| {
+            cookies.add(Cookie::new("session-id", "xxxx"));
+        })
+    });
+
+    let response = runner.perform("/").unwrap();
+
+    let h_str = response
+        .headers()
+        .get("set-cookie")
+        .expect("the header set-cookie is missing")
+        .to_str()
+        .unwrap();
+    let cookie = Cookie::parse_encoded(h_str).expect("failed to parse Set-Cookie");
+
+    assert_eq!(cookie.name(), "session-id");
+    assert_eq!(cookie.value(), "xxxx");
+}
+
+#[test]
+fn test_cookies_remove() {
+    let mut runner = test::runner({
+        endpoints::cookie::cookies().map(|mut cookies: Cookies| {
+            cookies.remove(Cookie::named("session-id"));
+        })
+    });
+
+    let response = runner
+        .perform(Request::get("/").header("cookie", "session-id=xxxx"))
+        .unwrap();
+
+    let h_str = response
+        .headers()
+        .get("set-cookie")
+        .expect("the header set-cookie is missing")
+        .to_str()
+        .unwrap();
+    let cookie = Cookie::parse_encoded(h_str).expect("failed to parse Set-Cookie");
+
+    assert_eq!(cookie.name(), "session-id");
+    assert_eq!(cookie.value(), "");
+}

--- a/tests/endpoints/mod.rs
+++ b/tests/endpoints/mod.rs
@@ -1,4 +1,5 @@
 mod body;
+mod cookie;
 mod header;
 mod query;
 mod upgrade;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,5 @@
 extern crate bytes;
+extern crate cookie;
 #[macro_use]
 extern crate failure;
 #[macro_use]


### PR DESCRIPTION
* make `required()` and `optional()` deprecated
* add `cookies()` which returns `input::Cookies`